### PR TITLE
Return an error object inline with the JSON RPC spec.

### DIFF
--- a/index.js
+++ b/index.js
@@ -119,7 +119,10 @@ Web3ProviderEngine.prototype._handleAsync = function(payload, finished) {
       }
 
       if (error != null) {
-        // resultObj.error = error.stack || error.message || error
+        // resultObj.error = {
+        //   message: error.stack || error.message || error,
+        //   code: -32000
+        // };
         // finished(null, resultObj)
         finished(error)
       } else {
@@ -209,7 +212,7 @@ Web3ProviderEngine.prototype._fetchBlock = function(number, cb){
 }
 
 Web3ProviderEngine.prototype._inspectResponseForNewBlock = function(payload, resultObj, cb) {
-  
+
   // these methods return responses with a block reference
   if (payload.method != 'eth_getTransactionByHash'
    && payload.method != 'eth_getTransactionReceipt') {


### PR DESCRIPTION
We were previously just returning an error message, which breaks the rpc spec and web3.