### PR TITLE
Cache Refactor + fixes / upgrade

### DIFF
--- a/index.js
+++ b/index.js
@@ -216,7 +216,7 @@ Web3ProviderEngine.prototype._inspectResponseForNewBlock = function(payload, res
     return cb(null, resultObj)
   }
 
-  if (resultObj.result !== null) {
+  if (resultObj.result == null || resultObj.result.blockNumber == null) {
     return cb(null, resultObj)
   }
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const inherits = require('util').inherits
 const Stoplight = require('./util/stoplight.js')
 const cacheUtils = require('./util/rpc-cache-utils.js')
 const createPayload = require('./util/create-payload.js')
-const async = require("./util/async.js");
+const async = require('./util/async.js');
 
 module.exports = Web3ProviderEngine
 
@@ -245,12 +245,12 @@ function SourceNotFoundError(payload){
 }
 
 function stripHexPrefix(hexString) {
-  return hexString.replace("0x", "");
+  return hexString.replace('0x', '');
 }
 
 function addHexPrefix(str) {
-  if (str.indexOf("0x") < 0) {
-    str = "0x" + str;
+  if (str.indexOf('0x') < 0) {
+    str = '0x' + str;
   }
   return str;
 }

--- a/subproviders/cache.js
+++ b/subproviders/cache.js
@@ -11,11 +11,22 @@ inherits(BlockCacheProvider, Subprovider)
 function BlockCacheProvider(opts) {
   const self = this
   opts = opts || {}
-  self._blockCache = {}
-  self._permaCache = {}
   self.cacheLength = opts.cacheLength || 4
   // set initialization blocker
   self._ready = new Stoplight()
+  self.strategies = {
+    perma: new PermaCacheStrategy(),
+    conditional: new ConditionalPermaCacheStrategy({
+      eth_getTransactionByHash: function(result) {
+        if (result && result.blockHash != null) {
+          return true;
+        }
+        return false;
+      }
+    }),
+    block: new BlockCacheStrategy(self),
+    fork: new BlockCacheStrategy(self),
+  }
 }
 
 // setup a block listener on 'setEngine'
@@ -28,16 +39,9 @@ BlockCacheProvider.prototype.setEngine = function(engine) {
   })
   // empty old cache
   engine.on('block', function(block) {
-    self.cacheRollOff()
+    self.strategies.block.cacheRollOff()
+    self.strategies.fork.cacheRollOff()
   })
-}
-
-// naively removes older block caches
-BlockCacheProvider.prototype.cacheRollOff = function(){
-  const self = this
-  var currentNumber = ethUtil.bufferToInt(self.currentBlock.number)
-  var previousHex = ethUtil.intToHex(currentNumber-1)
-  delete self._blockCache[previousHex]
 }
 
 BlockCacheProvider.prototype.handleRequest = function(payload, next, end){
@@ -64,79 +68,154 @@ BlockCacheProvider.prototype.handleRequest = function(payload, next, end){
 
 BlockCacheProvider.prototype._handleRequest = function(payload, next, end){
   const self = this
-  
-  // parse blockTag
-  var blockTag = cacheUtils.blockTagForPayload(payload)
-  // rewrite 'latest' blockTag to current block number
-  if (!blockTag || blockTag === 'latest') blockTag = bufferToHex(self.currentBlock.number)
-  var blockCache = self._cacheForBlockTag(blockTag)
-  var cacheIdentifier = cacheUtils.cacheIdentifierForPayload(payload)
 
-  //
-  // read from cache
-  //
+  var type = cacheUtils.cacheTypeForPayload(payload);
+  var strategy = this.strategies[type];
 
-  if (cacheIdentifier) {
-    var result = null
-    if (cacheUtils.canPermaCache(payload)) {
-      result = self._permaCache[cacheIdentifier]
-    } else if (blockCache) {
-      result = blockCache[cacheIdentifier]
-    }
-    
-    // if cache had a value, return it
-    // note: null is legitimate value (e.g. coinbase thats not set)
-    if (result !== undefined) {
-      // console.log('CACHE HIT:', result)
-      end(null, result)
-      return
-    } else {
-      // console.log('CACHE MISS:', blockTag, cacheIdentifier)
-    }
+  // If there's no strategy in place, pass it down the chain.
+  if (strategy == null) {
+    return next();
   }
 
-  //
-  // populate cache
-  //
+  // If the strategy can't cache this request, ignore it.
+  if (strategy.canCache(payload) == false) {
+    return next();
+  }
 
-  // fallthrough to provider chain, caching the result on the way back up.
-  next(function(err, result, cb) {
-    // err is already handled by engine
-    if (err) return cb()
-
-    // populate cache with result
-    if (cacheIdentifier && result !== undefined) {
-      // cache permanently (only truthy values)
-      if (result && cacheUtils.canPermaCache(payload)) {
-        self._permaCache[cacheIdentifier] = result
-        // console.log('CACHE POPULATE:', 'PERMA', cacheIdentifier, '->', result)
-      // cache for block (any value)
-      } else if (blockCache && cacheUtils.canBlockCache(payload)) {
-        blockCache[cacheIdentifier] = result
-        // console.log('CACHE POPULATE:', blockTag, cacheIdentifier, '->', result)
-      // cache miss
-      } else {
-        // console.log('CACHE POPULATE MISS:', blockTag, cacheIdentifier)
-      }
-    // cache not possible
-    } else {
-      // console.log('CACHE SKIP:', payload.method, result)
-    }
-
-    cb()
-  })
-}
-
-BlockCacheProvider.prototype._cacheForBlockTag = function(blockTag){
-  const self = this
-  if (!blockTag || blockTag === 'pending') return null
-  var cache = self._blockCache[blockTag]
-  // create new cache if necesary
-  if (!cache) cache = self._blockCache[blockTag] = {}
-  return cache
+  // end on a hit, continue on a miss
+  strategy.hitCheck(payload, end, function() {
+    // miss; fallthrough to provider chain, caching the result on the way back up.
+    next(function(err, result, cb) {
+      // err is already handled by engine
+      if (err) return cb()
+      strategy.cacheResult(payload, result, cb);
+    })
+  });
 }
 
 // TODO: This should be in utils somewhere.
 function bufferToHex(buffer){
   return ethUtil.addHexPrefix(buffer.toString('hex'))
+}
+
+function PermaCacheStrategy() {
+  this.cache = {};
+}
+
+PermaCacheStrategy.prototype.hitCheck = function(payload, hit, miss) {
+  var identifier = cacheUtils.cacheIdentifierForPayload(payload)
+  var cached = this.cache[identifier];
+
+  if (cached != null) {
+    return hit(null, cached);
+  } else {
+    return miss();
+  }
+};
+
+PermaCacheStrategy.prototype.cacheResult = function(payload, result, callback) {
+  var identifier = cacheUtils.cacheIdentifierForPayload(payload)
+
+  if (result != null) {
+    this.cache[identifier] = result;
+  }
+
+  callback();
+}
+
+PermaCacheStrategy.prototype.canCache = function(payload) {
+  return cacheUtils.canCache(payload)
+}
+
+function ConditionalPermaCacheStrategy(conditionals) {
+  this.strategy = new PermaCacheStrategy();
+  this.conditionals = conditionals;
+}
+
+ConditionalPermaCacheStrategy.prototype.hitCheck = function(payload, hit, miss) {
+  return this.strategy.hitCheck(payload, hit, miss);
+}
+
+ConditionalPermaCacheStrategy.prototype.cacheResult = function(payload, result, callback) {
+  var conditional = this.conditionals[payload.method];
+
+  if (conditional && conditional(result)) {
+    this.strategy.cacheResult(payload, result, callback);
+  } else {
+    callback();
+  }
+}
+
+ConditionalPermaCacheStrategy.prototype.canCache = function(payload) {
+  return this.strategy.canCache(payload);
+}
+
+function BlockCacheStrategy(subprovider) {
+  this.cache = {};
+  this.subprovider = subprovider;
+};
+
+BlockCacheStrategy.prototype.getBlockCache = function(payload) {
+  var blockTag = cacheUtils.blockTagForPayload(payload)
+
+  if (blockTag == "pending") {
+    return null;
+  }
+
+  // rewrite 'latest' blockTag to current block number
+  if (!blockTag || blockTag === 'latest') blockTag = bufferToHex(this.subprovider.currentBlock.number)
+
+  var blockCache = this.cache[blockTag]
+  // create new cache if necesary
+  if (!blockCache) blockCache = this.cache[blockTag] = {}
+
+  return blockCache;
+}
+
+BlockCacheStrategy.prototype.hitCheck = function(payload, hit, miss) {
+  var blockCache = this.getBlockCache(payload);
+
+  if (blockCache == null) {
+    return miss();
+  }
+
+  var identifier = cacheUtils.cacheIdentifierForPayload(payload);
+  var cached = blockCache[identifier];
+
+  if (cached != null) {
+    return hit(null, cached);
+  } else {
+    return miss();
+  }
+};
+
+BlockCacheStrategy.prototype.cacheResult = function(payload, result, callback) {
+  if (result != null) {
+    var blockCache = this.getBlockCache(payload);
+    var identifier = cacheUtils.cacheIdentifierForPayload(payload);
+    blockCache[identifier] = result;
+  }
+  callback();
+}
+
+BlockCacheStrategy.prototype.canCache = function(payload) {
+  if (cacheUtils.canCache(payload) == false) {
+    return false;
+  }
+
+  var blockTag = cacheUtils.blockTagForPayload(payload)
+
+  if (blockTag == "pending") {
+    return false;
+  }
+
+  return true;
+}
+
+// naively removes older block caches
+BlockCacheStrategy.prototype.cacheRollOff = function(){
+  const self = this
+  var currentNumber = ethUtil.bufferToInt(self.subprovider.currentBlock.number)
+  var previousHex = ethUtil.intToHex(currentNumber-1)
+  delete self.cache[previousHex]
 }

--- a/subproviders/cache.js
+++ b/subproviders/cache.js
@@ -84,7 +84,6 @@ BlockCacheProvider.prototype._handleRequest = function(payload, next, end){
   if (blockTag === 'earliest') {
     requestedBlockNumber = '0x00'
   } else if (blockTag === 'latest') {
-    // TODO: rewrite 'latest' blockTag to block number on payload
     requestedBlockNumber = bufferToHex(self.currentBlock.number)
   } else {
     // We have a hex number

--- a/subproviders/cache.js
+++ b/subproviders/cache.js
@@ -16,11 +16,8 @@ function BlockCacheProvider(opts) {
   self.strategies = {
     perma: new ConditionalPermaCacheStrategy({
       eth_getTransactionByHash: function(result) {
-        if (result && result.blockHash != null) {
-          return true;
-        }
-        return false;
-      }
+        return Boolean(result && result.blockHash)
+      },
     }),
     block: new BlockCacheStrategy(self),
     fork: new BlockCacheStrategy(self),
@@ -67,44 +64,44 @@ BlockCacheProvider.prototype.handleRequest = function(payload, next, end){
 BlockCacheProvider.prototype._handleRequest = function(payload, next, end){
   const self = this
 
-  var type = cacheUtils.cacheTypeForPayload(payload);
-  var strategy = this.strategies[type];
+  var type = cacheUtils.cacheTypeForPayload(payload)
+  var strategy = this.strategies[type]
 
   // If there's no strategy in place, pass it down the chain.
-  if (strategy == null) {
-    return next();
+  if (!strategy) {
+    return next()
   }
 
   // If the strategy can't cache this request, ignore it.
-  if (strategy.canCache(payload) == false) {
-    return next();
+  if (!strategy.canCache(payload)) {
+    return next()
   }
 
-  var blockTag = cacheUtils.blockTagForPayload(payload);
-  var requestedBlockNumber = bufferToBN(this.currentBlock.number);
+  var blockTag = cacheUtils.blockTagForPayload(payload)
+  var requestedBlockNumber = bufferToBN(this.currentBlock.number)
 
-  if (blockTag != null) {
-    if (blockTag == "earliest") {
-      requestedBlockNumber = new ethUtil.BN("0", "hex");
-    } else if (blockTag == "latest") {
+  if (blockTag) {
+    if (blockTag === 'earliest') {
+      requestedBlockNumber = new ethUtil.BN('0', 'hex')
+    } else if (blockTag === 'latest') {
       // already set to latest
     } else {
       // We have a hex number
-      requestedBlockNumber = new ethUtil.BN(blockTag, "hex");
+      requestedBlockNumber = new ethUtil.BN(blockTag, 'hex')
     }
   }
 
-  //console.log("REQUEST at block 0x" + requestedBlockNumber.toString("hex"));
+  //console.log('REQUEST at block 0x' + requestedBlockNumber.toString('hex'))
 
   // end on a hit, continue on a miss
   strategy.hitCheck(payload, requestedBlockNumber, end, function() {
-    // miss; fallthrough to provider chain, caching the result on the way back up.
+    // miss fallthrough to provider chain, caching the result on the way back up.
     next(function(err, result, cb) {
       // err is already handled by engine
       if (err) return cb()
-      strategy.cacheResult(payload, result, requestedBlockNumber, cb);
+      strategy.cacheResult(payload, result, requestedBlockNumber, cb)
     })
-  });
+  })
 }
 
 // TODO: This should be in utils somewhere.
@@ -113,39 +110,39 @@ function bufferToHex(buffer){
 }
 
 function bufferToBN(buffer) {
-  return new ethUtil.BN(buffer.toString('hex'), "hex");
+  return new ethUtil.BN(buffer.toString('hex'), 'hex')
 }
 
 function PermaCacheStrategy() {
-  this.cache = {};
+  this.cache = {}
 }
 
 PermaCacheStrategy.prototype.hitCheck = function(payload, requestedBlockNumber, hit, miss) {
   var identifier = cacheUtils.cacheIdentifierForPayload(payload)
-  var cached = this.cache[identifier];
+  var cached = this.cache[identifier]
 
-  if (cached != null && requestedBlockNumber.gte(cached.blockNumber)) {
+  if (cached && requestedBlockNumber.gte(cached.blockNumber)) {
     // If the block number we're requesting at is greater than or
     // equal to the block where we cached a previous response, return
     // the previous response. If it's less than the current block,
     // send it back down to the client where it will be recached.
-    return hit(null, cached.result);
+    return hit(null, cached.result)
   } else {
-    return miss();
+    return miss()
   }
-};
+}
 
 PermaCacheStrategy.prototype.cacheResult = function(payload, result, requestedBlockNumber, callback) {
   var identifier = cacheUtils.cacheIdentifierForPayload(payload)
 
-  if (result != null) {
+  if (result) {
     this.cache[identifier] = {
       blockNumber: requestedBlockNumber,
       result: result
-    };
+    }
   }
 
-  callback();
+  callback()
 }
 
 PermaCacheStrategy.prototype.canCache = function(payload) {
@@ -153,88 +150,84 @@ PermaCacheStrategy.prototype.canCache = function(payload) {
 }
 
 function ConditionalPermaCacheStrategy(conditionals) {
-  this.strategy = new PermaCacheStrategy();
-  this.conditionals = conditionals;
+  this.strategy = new PermaCacheStrategy()
+  this.conditionals = conditionals
 }
 
 ConditionalPermaCacheStrategy.prototype.hitCheck = function(payload, requestedBlockNumber, hit, miss) {
-  return this.strategy.hitCheck(payload, requestedBlockNumber, hit, miss);
+  return this.strategy.hitCheck(payload, requestedBlockNumber, hit, miss)
 }
 
 ConditionalPermaCacheStrategy.prototype.cacheResult = function(payload, result, requestedBlockNumber, callback) {
-  var conditional = this.conditionals[payload.method];
+  var conditional = this.conditionals[payload.method]
 
-  if (conditional != null) {
+  if (conditional) {
     if (conditional(result)) {
-      this.strategy.cacheResult(payload, result, requestedBlockNumber, callback);
+      this.strategy.cacheResult(payload, result, requestedBlockNumber, callback)
     } else {
-      callback();
+      callback()
     }
   } else {
     // Cache all requests that don't have a conditional
-    this.strategy.cacheResult(payload, result, requestedBlockNumber, callback);
+    this.strategy.cacheResult(payload, result, requestedBlockNumber, callback)
   }
 }
 
 ConditionalPermaCacheStrategy.prototype.canCache = function(payload) {
-  return this.strategy.canCache(payload);
+  return this.strategy.canCache(payload)
 }
 
 function BlockCacheStrategy() {
-  this.cache = {};
-};
+  this.cache = {}
+}
 
 BlockCacheStrategy.prototype.getBlockCacheForPayload = function(payload, currentBlockNumber) {
   var blockTag = cacheUtils.blockTagForPayload(payload)
 
   // rewrite 'latest' blockTag to current block number
-  if (!blockTag || blockTag === 'latest') blockTag = "0x" + currentBlockNumber.toString("hex")
+  if (!blockTag || blockTag === 'latest') blockTag = '0x' + currentBlockNumber.toString('hex')
 
   var blockCache = this.cache[blockTag]
   // create new cache if necesary
   if (!blockCache) blockCache = this.cache[blockTag] = {}
 
-  return blockCache;
+  return blockCache
 }
 
 BlockCacheStrategy.prototype.hitCheck = function(payload, requestedBlockNumber, hit, miss) {
-  var blockCache = this.getBlockCacheForPayload(payload, requestedBlockNumber);
+  var blockCache = this.getBlockCacheForPayload(payload, requestedBlockNumber)
 
-  if (blockCache == null) {
-    return miss();
+  if (!blockCache) {
+    return miss()
   }
 
-  var identifier = cacheUtils.cacheIdentifierForPayload(payload);
-  var cached = blockCache[identifier];
+  var identifier = cacheUtils.cacheIdentifierForPayload(payload)
+  var cached = blockCache[identifier]
 
-  if (cached != null) {
-    return hit(null, cached);
+  if (cached) {
+    return hit(null, cached)
   } else {
-    return miss();
+    return miss()
   }
-};
+}
 
 BlockCacheStrategy.prototype.cacheResult = function(payload, result, requestedBlockNumber, callback) {
-  if (result != null) {
-    var blockCache = this.getBlockCacheForPayload(payload, requestedBlockNumber);
-    var identifier = cacheUtils.cacheIdentifierForPayload(payload);
-    blockCache[identifier] = result;
+  if (result) {
+    var blockCache = this.getBlockCacheForPayload(payload, requestedBlockNumber)
+    var identifier = cacheUtils.cacheIdentifierForPayload(payload)
+    blockCache[identifier] = result
   }
-  callback();
+  callback()
 }
 
 BlockCacheStrategy.prototype.canCache = function(payload) {
-  if (cacheUtils.canCache(payload) == false) {
-    return false;
+  if (!cacheUtils.canCache(payload)) {
+    return false
   }
 
   var blockTag = cacheUtils.blockTagForPayload(payload)
 
-  if (blockTag == "pending") {
-    return false;
-  }
-
-  return true;
+  return (blockTag !== 'pending')
 }
 
 // naively removes older block caches

--- a/subproviders/fixture.js
+++ b/subproviders/fixture.js
@@ -16,7 +16,7 @@ FixtureProvider.prototype.handleRequest = function(payload, next, end){
   var staticResponse = self.staticResponses[payload.method]
   // async function
   if ('function' === typeof staticResponse) {
-    staticResponse(end)
+    staticResponse(payload, next, end)
   // static response - null is valid response
   } else if (staticResponse !== undefined) {
     end(null, staticResponse)

--- a/test/basic.js
+++ b/test/basic.js
@@ -31,10 +31,10 @@ test('fallthrough test', function(t){
 
     t.equal(providerA.getWitnessed('test_rpc').length, 1, 'providerA did see "test_rpc"')
     t.equal(providerA.getHandled('test_rpc').length, 0, 'providerA did NOT handle "test_rpc"')
-    
+
     t.equal(providerB.getWitnessed('test_rpc').length, 1, 'providerB did see "test_rpc"')
     t.equal(providerB.getHandled('test_rpc').length, 1, 'providerB did handle "test_rpc"')
-    
+
     t.equal(providerC.getWitnessed('test_rpc').length, 0, 'providerC did NOT see "test_rpc"')
     t.equal(providerC.getHandled('test_rpc').length, 0, 'providerC did NOT handle "test_rpc"')
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -6,6 +6,7 @@ const TestBlockProvider = require('./util/block.js')
 const createPayload = require('../util/create-payload.js')
 const injectMetrics = require('./util/inject-metrics')
 
+
 cacheTest('getBalance + undefined blockTag', {
   method: 'eth_getBalance',
   params: ['0x1234'],
@@ -21,12 +22,12 @@ cacheTest('getBalance + pending blockTag', {
   params: ['0x1234', 'pending'],
 }, false)
 
-cacheTest("getTransactionByHash for transaction that doesn't exist", {
+cacheTest('getTransactionByHash for transaction that doesn\'t exist', {
   method: 'eth_getTransactionByHash',
   params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe00'],
 }, false)
 
-cacheTest("getTransactionByHash for transaction that's pending", {
+cacheTest('getTransactionByHash for transaction that\'s pending', {
   method: 'eth_getTransactionByHash',
   params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe01'],
 }, false)
@@ -36,50 +37,43 @@ cacheTest('getTransactionByHash for mined transaction', {
   params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe02'],
 }, true)
 
-cacheTest('getCode for latest block, then for earliest block, should not return cached response on second request', [
-  {
-    method: 'eth_getCode',
-    params: ['0x1234', 'latest'],
-  },
-  {
-    method: 'eth_getCode',
-    params: ['0x1234', 'earliest'],
-  }
-], false)
+cacheTest('getCode for latest block, then for earliest block, should not return cached response on second request', [{
+  method: 'eth_getCode',
+  params: ['0x1234', 'latest'],
+}, {
+  method: 'eth_getCode',
+  params: ['0x1234', 'earliest'],
+}], false)
 
-cacheTest('getCode for a specific block, then for the one before it, should not return cached response on second request', [
-  {
-    method: 'eth_getCode',
-    params: ['0x1234', '0x3'],
-  },
-  {
-    method: 'eth_getCode',
-    params: ['0x1234', '0x2'],
-  }
-], false)
+cacheTest('getCode for a specific block, then for the one before it, should not return cached response on second request', [{
+  method: 'eth_getCode',
+  params: ['0x1234', '0x3'],
+}, {
+  method: 'eth_getCode',
+  params: ['0x1234', '0x2'],
+}], false)
 
-cacheTest('getCode for a specific block, then the one after it, should return cached response on second request', [
-  {
-    method: 'eth_getCode',
-    params: ['0x1234', '0x2'],
-  },
-  {
-    method: 'eth_getCode',
-    params: ['0x1234', '0x3'],
-  }
-], true)
+cacheTest('getCode for a specific block, then the one after it, should return cached response on second request', [{
+  method: 'eth_getCode',
+  params: ['0x1234', '0x2'],
+}, {
+  method: 'eth_getCode',
+  params: ['0x1234', '0x3'],
+}], true)
 
-cacheTest('getCode for an unspecified block, then for the latest, should return cached response on second request', [
-  {
-    method: 'eth_getCode',
-    params: ['0x1234'],
-  },
-  {
-    method: 'eth_getCode',
-    params: ['0x1234', 'latest'],
-  }
-], true)
+cacheTest('getCode for an unspecified block, then for the latest, should return cached response on second request', [{
+  method: 'eth_getCode',
+  params: ['0x1234'],
+}, {
+  method: 'eth_getCode',
+  params: ['0x1234', 'latest'],
+}], true)
 
+// test helper for caching
+// 1. Sets up caching and data provider
+// 2. Performs first request
+// 3. Performs second request
+// 4. checks if cache hit or missed 
 
 function cacheTest(label, payloads, shouldHitOnSecondRequest){
 
@@ -93,36 +87,36 @@ function cacheTest(label, payloads, shouldHitOnSecondRequest){
       eth_getBalance: '0xdeadbeef',
       eth_getCode: '6060604052600560005560408060156000396000f3606060405260e060020a60003504633fa4f245811460245780635524107714602c575b005b603660005481565b6004356000556022565b6060908152602090f3',
       eth_getTransactionByHash: function(payload, next, end) {
-        // Test; meant to represent a pending trasnaction
-        if (payload.params[0] == "0x00000000000000000000000000000000000000000000000000deadbeefcafe00") {
+        // represents a pending tx
+        if (payload.params[0] === '0x00000000000000000000000000000000000000000000000000deadbeefcafe00') {
           end(null, null)
-        } else if (payload.params[0] == "0x00000000000000000000000000000000000000000000000000deadbeefcafe01") {
+        } else if (payload.params[0] === '0x00000000000000000000000000000000000000000000000000deadbeefcafe01') {
           end(null, {
-            "hash": "0x00000000000000000000000000000000000000000000000000deadbeefcafe01",
-            "nonce": "0xd",
-            "blockHash": null,
-            "blockNumber": null,
-            "transactionIndex": null,
-            "from": "0xb1cc05ab12928297911695b55ee78c1188f8ef91",
-            "to": "0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98",
-            "value": "0xddb66b2addf4800",
-            "gas": "0x5622",
-            "gasPrice": "0xba43b7400",
-            "input": "0x"
-          });
+            hash: '0x00000000000000000000000000000000000000000000000000deadbeefcafe01',
+            nonce: '0xd',
+            blockHash: null,
+            blockNumber: null,
+            transactionIndex: null,
+            from: '0xb1cc05ab12928297911695b55ee78c1188f8ef91',
+            to: '0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98',
+            value: '0xddb66b2addf4800',
+            gas: '0x5622',
+            gasPrice: '0xba43b7400',
+            input: '0x',
+          })
         } else {
           end(null, {
-            "hash": payload.params[0],
-            "nonce": "0xd",
-            "blockHash": "0x1",
-            "blockNumber": "0x1",
-            "transactionIndex": "0x0",
-            "from": "0xb1cc05ab12928297911695b55ee78c1188f8ef91",
-            "to": "0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98",
-            "value": "0xddb66b2addf4800",
-            "gas": "0x5622",
-            "gasPrice": "0xba43b7400",
-            "input": "0x"
+            hash: payload.params[0],
+            nonce: '0xd',
+            blockHash: '0x1',
+            blockNumber: '0x1',
+            transactionIndex: '0x0',
+            from: '0xb1cc05ab12928297911695b55ee78c1188f8ef91',
+            to: '0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98',
+            value: '0xddb66b2addf4800',
+            gas: '0x5622',
+            gasPrice: '0xba43b7400',
+            input: '0x',
           })
         }
       }
@@ -143,8 +137,8 @@ function cacheTest(label, payloads, shouldHitOnSecondRequest){
     })
 
     function cacheCheck(t, engine, cacheProvider, dataProvider, payloads, cb) {
-      if (payloads instanceof Array == false) {
-        payloads = [payloads, payloads];
+      if (!Array.isArray(payloads)) {
+        payloads = [payloads, payloads]
       }
 
       var method = payloads[0].method
@@ -164,7 +158,7 @@ function cacheTest(label, payloads, shouldHitOnSecondRequest){
         t.notOk(err || response.error, 'did not error')
         t.ok(response, 'has response')
 
-        if (shouldHitOnSecondRequest == true) {
+        if (shouldHitOnSecondRequest) {
           t.equal(cacheProvider.getWitnessed(method).length, 2, 'cacheProvider did see "'+method+'"')
           t.equal(cacheProvider.getHandled(method).length, 1, 'cacheProvider did handle "'+method+'"')
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -9,20 +9,35 @@ const injectMetrics = require('./util/inject-metrics')
 cacheTest('getBalance + undefined blockTag', {
   method: 'eth_getBalance',
   params: ['0x1234'],
-})
+}, true)
 
 cacheTest('getBalance + latest blockTag', {
   method: 'eth_getBalance',
   params: ['0x1234', 'latest'],
-})
+}, true)
 
 cacheTest('getBalance + pending blockTag', {
   method: 'eth_getBalance',
   params: ['0x1234', 'pending'],
-})
+}, false)
+
+cacheTest("getTransactionByHash for transaction that doesn't exist", {
+  method: 'eth_getTransactionByHash',
+  params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe00'],
+}, false)
+
+cacheTest("getTransactionByHash for transaction that's pending", {
+  method: 'eth_getTransactionByHash',
+  params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe01'],
+}, false)
+
+cacheTest('getTransactionByHash for mined transaction', {
+  method: 'eth_getTransactionByHash',
+  params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe02'],
+}, true)
 
 
-function cacheTest(label, payload){
+function cacheTest(label, payload, shouldCache){
 
   test('cache - '+label, function(t){
     t.plan(12)
@@ -32,6 +47,40 @@ function cacheTest(label, payload){
     // handle balance
     var dataProvider = injectMetrics(new FixtureProvider({
       eth_getBalance: '0xdeadbeef',
+      eth_getTransactionByHash: function(payload, next, end) {
+        // Test; meant to represent a pending trasnaction
+        if (payload.params[0] == "0x00000000000000000000000000000000000000000000000000deadbeefcafe00") {
+          end(null, null)
+        } else if (payload.params[0] == "0x00000000000000000000000000000000000000000000000000deadbeefcafe01") {
+          end(null, {
+            "hash": "0x00000000000000000000000000000000000000000000000000deadbeefcafe01",
+            "nonce": "0xd",
+            "blockHash": null,
+            "blockNumber": null,
+            "transactionIndex": null,
+            "from": "0xb1cc05ab12928297911695b55ee78c1188f8ef91",
+            "to": "0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98",
+            "value": "0xddb66b2addf4800",
+            "gas": "0x5622",
+            "gasPrice": "0xba43b7400",
+            "input": "0x"
+          });
+        } else {
+          end(null, {
+            "hash": payload.params[0],
+            "nonce": "0xd",
+            "blockHash": "0x1",
+            "blockNumber": "0x1",
+            "transactionIndex": "0x0",
+            "from": "0xb1cc05ab12928297911695b55ee78c1188f8ef91",
+            "to": "0xfbb1b73c4f0bda4f67dca266ce6ef42f520fbb98",
+            "value": "0xddb66b2addf4800",
+            "gas": "0x5622",
+            "gasPrice": "0xba43b7400",
+            "input": "0x"
+          })
+        }
+      }
     }))
     // handle dummy block
     var blockProvider = injectMetrics(new TestBlockProvider())
@@ -43,10 +92,7 @@ function cacheTest(label, payload){
 
     engine.start()
 
-    cacheCheck(t, engine, cacheProvider, dataProvider, {
-      method: 'eth_getBalance',
-      params: ['0x1234', 'latest'],
-    }, function(err, response){
+    cacheCheck(t, engine, cacheProvider, dataProvider, payload, function(err, response){
       engine.stop()
       t.end()
     })
@@ -60,20 +106,28 @@ function cacheTest(label, payload){
 
         t.equal(cacheProvider.getWitnessed(method).length, 1, 'cacheProvider did see "'+method+'"')
         t.equal(cacheProvider.getHandled(method).length, 0, 'cacheProvider did NOT handle "'+method+'"')
-        
+
         t.equal(dataProvider.getWitnessed(method).length, 1, 'dataProvider did see "'+method+'"')
         t.equal(dataProvider.getHandled(method).length, 1, 'dataProvider did handle "'+method+'"')
-      
+
       }, function(err, response){
         // second request
         t.notOk(err || response.error, 'did not error')
         t.ok(response, 'has response')
 
-        t.equal(cacheProvider.getWitnessed(method).length, 2, 'cacheProvider did see "'+method+'"')
-        t.equal(cacheProvider.getHandled(method).length, 1, 'cacheProvider did handle "'+method+'"')
-        
-        t.equal(dataProvider.getWitnessed(method).length, 1, 'dataProvider did NOT see "'+method+'"')
-        t.equal(dataProvider.getHandled(method).length, 1, 'dataProvider did NOT handle "'+method+'"')
+        if (shouldCache == true) {
+          t.equal(cacheProvider.getWitnessed(method).length, 2, 'cacheProvider did see "'+method+'"')
+          t.equal(cacheProvider.getHandled(method).length, 1, 'cacheProvider did handle "'+method+'"')
+
+          t.equal(dataProvider.getWitnessed(method).length, 1, 'dataProvider did NOT see "'+method+'"')
+          t.equal(dataProvider.getHandled(method).length, 1, 'dataProvider did NOT handle "'+method+'"')
+        } else {
+          t.equal(cacheProvider.getWitnessed(method).length, 2, 'cacheProvider did see "'+method+'"')
+          t.equal(cacheProvider.getHandled(method).length, 0, 'cacheProvider did handle "'+method+'"')
+
+          t.equal(dataProvider.getWitnessed(method).length, 2, 'dataProvider did NOT see "'+method+'"')
+          t.equal(dataProvider.getHandled(method).length, 2, 'dataProvider did NOT handle "'+method+'"')
+        }
 
         cb()
       })
@@ -82,11 +136,10 @@ function cacheTest(label, payload){
     function requestTwice(payload, afterFirst, afterSecond){
       engine.sendAsync(createPayload(payload), function(err, result){
         afterFirst(err, result)
-        engine.sendAsync(createPayload(payload), afterSecond)  
+        engine.sendAsync(createPayload(payload), afterSecond)
       })
     }
 
   })
 
 }
-

--- a/test/cache.js
+++ b/test/cache.js
@@ -36,7 +36,6 @@ cacheTest('getTransactionByHash for mined transaction', {
   params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe02'],
 }, true)
 
-
 cacheTest('getCode for latest block, then for earliest block, should not return cached response on second request', [
   {
     method: 'eth_getCode',
@@ -47,6 +46,28 @@ cacheTest('getCode for latest block, then for earliest block, should not return 
     params: ['0x1234', 'earliest'],
   }
 ], false)
+
+cacheTest('getCode for a specific block, then for the one before it, should not return cached response on second request', [
+  {
+    method: 'eth_getCode',
+    params: ['0x1234', '0x3'],
+  },
+  {
+    method: 'eth_getCode',
+    params: ['0x1234', '0x2'],
+  }
+], false)
+
+cacheTest('getCode for a specific block, then the one after it, should return cached response on second request', [
+  {
+    method: 'eth_getCode',
+    params: ['0x1234', '0x2'],
+  },
+  {
+    method: 'eth_getCode',
+    params: ['0x1234', '0x3'],
+  }
+], true)
 
 
 function cacheTest(label, payloads, shouldHitOnSecondRequest){

--- a/test/cache.js
+++ b/test/cache.js
@@ -69,6 +69,17 @@ cacheTest('getCode for a specific block, then the one after it, should return ca
   }
 ], true)
 
+cacheTest('getCode for an unspecified block, then for the latest, should return cached response on second request', [
+  {
+    method: 'eth_getCode',
+    params: ['0x1234'],
+  },
+  {
+    method: 'eth_getCode',
+    params: ['0x1234', 'latest'],
+  }
+], true)
+
 
 function cacheTest(label, payloads, shouldHitOnSecondRequest){
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -6,6 +6,7 @@ const TestBlockProvider = require('./util/block.js')
 const createPayload = require('../util/create-payload.js')
 const injectMetrics = require('./util/inject-metrics')
 
+// skip cache
 
 cacheTest('skipCache - true', {
   method: 'eth_getBalance',
@@ -16,6 +17,8 @@ cacheTest('skipCache - false', {
   method: 'eth_getBalance',
   skipCache: false,
 }, true)
+
+// block tags
 
 cacheTest('getBalance + undefined blockTag', {
   method: 'eth_getBalance',
@@ -32,6 +35,8 @@ cacheTest('getBalance + pending blockTag', {
   params: ['0x1234', 'pending'],
 }, false)
 
+// tx by hash
+
 cacheTest('getTransactionByHash for transaction that doesn\'t exist', {
   method: 'eth_getTransactionByHash',
   params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe00'],
@@ -46,6 +51,8 @@ cacheTest('getTransactionByHash for mined transaction', {
   method: 'eth_getTransactionByHash',
   params: ['0x00000000000000000000000000000000000000000000000000deadbeefcafe02'],
 }, true)
+
+// code
 
 cacheTest('getCode for latest block, then for earliest block, should not return cached response on second request', [{
   method: 'eth_getCode',

--- a/test/cache.js
+++ b/test/cache.js
@@ -7,6 +7,16 @@ const createPayload = require('../util/create-payload.js')
 const injectMetrics = require('./util/inject-metrics')
 
 
+cacheTest('skipCache - true', {
+  method: 'eth_getBalance',
+  skipCache: true,
+}, false)
+
+cacheTest('skipCache - false', {
+  method: 'eth_getBalance',
+  skipCache: false,
+}, true)
+
 cacheTest('getBalance + undefined blockTag', {
   method: 'eth_getBalance',
   params: ['0x1234'],
@@ -75,7 +85,7 @@ cacheTest('getCode for an unspecified block, then for the latest, should return 
 // 3. Performs second request
 // 4. checks if cache hit or missed 
 
-function cacheTest(label, payloads, shouldHitOnSecondRequest){
+function cacheTest(label, payloads, shouldHitCacheOnSecondRequest){
 
   test('cache - '+label, function(t){
     t.plan(12)
@@ -144,7 +154,7 @@ function cacheTest(label, payloads, shouldHitOnSecondRequest){
       var method = payloads[0].method
       requestTwice(payloads, function(err, response){
         // first request
-        t.ifError(err || response.error, 'did not error')
+        t.ifError(err || response.error && response.error.message, 'did not error')
         t.ok(response, 'has response')
 
         t.equal(cacheProvider.getWitnessed(method).length, 1, 'cacheProvider did see "'+method+'"')
@@ -155,10 +165,10 @@ function cacheTest(label, payloads, shouldHitOnSecondRequest){
 
       }, function(err, response){
         // second request
-        t.notOk(err || response.error, 'did not error')
+        t.ifError(err || response.error && response.error.message, 'did not error')
         t.ok(response, 'has response')
 
-        if (shouldHitOnSecondRequest) {
+        if (shouldHitCacheOnSecondRequest) {
           t.equal(cacheProvider.getWitnessed(method).length, 2, 'cacheProvider did see "'+method+'"')
           t.equal(cacheProvider.getHandled(method).length, 1, 'cacheProvider did handle "'+method+'"')
 

--- a/test/util/block.js
+++ b/test/util/block.js
@@ -16,11 +16,11 @@ function TestBlockProvider(methods){
   self._currentBlock = createBlock()
   self._pendingTxs = []
   FixtureProvider.call(self, {
-    eth_getBlockByNumber: function(cb){
-      cb(null, self._currentBlock)
+    eth_getBlockByNumber: function(payload, next, end){
+      end(null, self._currentBlock)
     },
-    eth_getLogs: function(cb){
-      cb(null, self._currentBlock.transactions)
+    eth_getLogs: function(payload, next, end){
+      end(null, self._currentBlock.transactions)
     },
   })
 }

--- a/util/create-payload.js
+++ b/util/create-payload.js
@@ -1,13 +1,15 @@
 const getRandomId = require('./random-id.js')
+const extend = require('xtend')
 
 module.exports = createPayload
 
 
 function createPayload(data){
-  return {
-    id: data.id === undefined ? getRandomId() : data.id,
-    jsonrpc: data.jsonrpc  === undefined ? '2.0' : data.jsonrpc,
-    method: data.method,
-    params: data.params || [],
-  }
+  return extend({
+    // defaults
+    id: getRandomId(),
+    jsonrpc: '2.0',
+    params: [],
+    // user-specified
+  }, data)
 }

--- a/util/rpc-cache-utils.js
+++ b/util/rpc-cache-utils.js
@@ -1,7 +1,5 @@
 module.exports = {
   cacheIdentifierForPayload: cacheIdentifierForPayload,
-  canBlockCache: canBlockCache,
-  canPermaCache: canPermaCache,
   canCache: canCache,
   blockTagForPayload: blockTagForPayload,
   paramsWithoutBlockTag: paramsWithoutBlockTag,
@@ -16,15 +14,6 @@ function cacheIdentifierForPayload(payload){
   } else {
     return null
   }
-}
-
-function canBlockCache(payload){
-  var type = cacheTypeForPayload(payload)
-  return type === 'perma' || type === 'fork' || type === 'block'
-}
-
-function canPermaCache(payload){
-  return cacheTypeForPayload(payload) === 'perma'
 }
 
 function canCache(payload){
@@ -90,7 +79,7 @@ function cacheTypeForPayload(payload) {
     case 'eth_getCode':
     case 'eth_sign':
     case 'eth_getBlockByHash':
-    case 'eth_getTransactionByHash':
+
     case 'eth_getTransactionByBlockHashAndIndex':
     case 'eth_getTransactionReceipt':
     case 'eth_getUncleByBlockHashAndIndex':
@@ -100,6 +89,9 @@ function cacheTypeForPayload(payload) {
     case 'eth_compileSerpent':
     case 'shh_version':
       return 'perma'
+
+    case 'eth_getTransactionByHash':
+      return 'conditional'
 
     // cache until fork
     case 'eth_getBlockByNumber':

--- a/util/rpc-cache-utils.js
+++ b/util/rpc-cache-utils.js
@@ -79,7 +79,7 @@ function cacheTypeForPayload(payload) {
     case 'eth_getCode':
     case 'eth_sign':
     case 'eth_getBlockByHash':
-
+    case 'eth_getTransactionByHash':
     case 'eth_getTransactionByBlockHashAndIndex':
     case 'eth_getTransactionReceipt':
     case 'eth_getUncleByBlockHashAndIndex':
@@ -89,9 +89,6 @@ function cacheTypeForPayload(payload) {
     case 'eth_compileSerpent':
     case 'shh_version':
       return 'perma'
-
-    case 'eth_getTransactionByHash':
-      return 'conditional'
 
     // cache until fork
     case 'eth_getBlockByNumber':

--- a/util/rpc-cache-utils.js
+++ b/util/rpc-cache-utils.js
@@ -21,43 +21,37 @@ function canCache(payload){
 }
 
 function blockTagForPayload(payload){
-  switch(blockTagParamIndex(payload)) {
-    // blockTag is first param
-    case 0:
-      return payload.params[0]
-    // blockTag is last param
-    case -1:
-      return payload.params[payload.params.length-1]
-    // there is no blockTag
-    default:
-      return null
+  var index = blockTagParamIndex(payload);
+
+  // Block tag param not passed.
+  if (index >= payload.params.length) {
+    return null;
   }
+
+  return payload.params[index];
 }
 
 function paramsWithoutBlockTag(payload){
-  switch(blockTagParamIndex(payload)) {
-    // blockTag is first param
-    case 0:
-      return payload.params.slice(1)
-    // blockTag is last param
-    case -1:
-      return payload.params.slice(0,-1)
-    // there is no blockTag
-    default:
-      return payload.params.slice()
+  var index = blockTagParamIndex(payload);
+
+  // Block tag param not passed.
+  if (index >= payload.params.length) {
+    return payload.params;
   }
+
+  return payload.params.slice(0,index);
 }
 
 function blockTagParamIndex(payload){
   switch(payload.method) {
-    // blockTag is last param
+    // blockTag is second param
     case 'eth_getBalance':
     case 'eth_getCode':
     case 'eth_getTransactionCount':
     case 'eth_getStorageAt':
     case 'eth_call':
     case 'eth_estimateGas':
-      return -1
+      return 1
     // blockTag is first param
     case 'eth_getBlockByNumber':
       return 0


### PR DESCRIPTION
Many things:

* Refactor caching logic into separate strategies based on cache type (in the future, we may want to determine caching strategies directly from the RPC method rather than going from RPC method -> type -> strategy)
* Fix cache tests so that they run three different tests rather than one test three times (see comment on #14)
* Make `eth_getTransactionByHash` conditionally cache based on response (fixes #14)
* Add tests for `eth_getTransactionByHash`'s conditional caching (this required a modification to the Fixture subprovider to allow for conditional responses based on payload)