### PR TITLE
VM Subprovider Squelching errors

### DIFF
--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -100,23 +100,15 @@ VmSubprovider.prototype.runVm = function(payload, cb){
     block: block,
     skipNonce: true,
   }, function(err, results) {
-    if (err) {
-      if (isNormalVmError(err.message)) {
-        return cb(null, { error: err })
-      } else {
-        return cb(err)
-      }
-    }
-
-    if (results.error != null) {
+    if (results && results.error != null) {
       return cb(new Error("VM error: " + results.error));
     }
 
-    if (results.vm.exception != 1) {
+    if (results && results.vm && results.vm.exception != 1) {
       return cb(new Error("VM Exception while executing " + payload.method + ": " + results.vm.exceptionError));
     }
 
-    cb(null, results)
+    cb(err, results)
   })
 
 }


### PR DESCRIPTION
I'm finding that this block squelches errors. Also, it's normalizing errors into RPC error format (result.error = ...), which is done by the engine. I think we should remove the block in favor of these other minor changes.