### PR TITLE
Use runCall() instead of runTx() in the VMSubprovider

### DIFF
--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -100,23 +100,15 @@ VmSubprovider.prototype.runVm = function(payload, cb){
     block: block,
     skipNonce: true,
   }, function(err, results) {
-    if (err) {
-      if (isNormalVmError(err.message)) {
-        return cb(null, { error: err })
-      } else {
-        return cb(err)
-      }
-    }
-
-    if (results.error != null) {
+    if (results && results.error != null) {
       return cb(new Error("VM error: " + results.error));
     }
 
-    if (results.vm.exception != 1) {
+    if (results && results.vm && results.vm.exception != 1) {
       return cb(new Error("VM Exception while executing " + payload.method + ": " + results.vm.exceptionError));
     }
 
-    cb(null, results)
+    cb(err, results)
   })
 
 }


### PR DESCRIPTION
This required a few gotchas:

1. We have to get the contract code ourselves because `runCall()` tries to get it from the cache, which returns nothing.
2. We have to calculate the correct gas costs ourselves because `runTx()` does that originally. In order to get the correct base fee (see code), we need ethereumjs-tx, which isn't so bad because it was a dependency already. Note that the gas usage calculations are a direct copy from the `runTx()` code - there doesn't seem to be a better way to do it without making changes upstream.

This fixes:

* A very rare issue where if `eth_estimateGas` is called from an account that doesn't exist while simultaneously passing in a custom `gasPrice`, the method will result in the error: `Error: sender doesn't have enough funds to send tx. The upfront cost is: 3141592 and the senders account only has: 0`. More details from the testrpc project here: https://github.com/ethereumjs/testrpc/issues/16. Once this PR is merged I will be adding a test to the testrpc which exercises this case.
