### PR TITLE
Cache: do not fail when block.number = 0

### DIFF
--- a/subproviders/cache.js
+++ b/subproviders/cache.js
@@ -235,8 +235,10 @@ BlockCacheStrategy.prototype.canCache = function(payload) {
 BlockCacheStrategy.prototype.cacheRollOff = function(currentBlock){
   const self = this
   var currentNumber = ethUtil.bufferToInt(currentBlock.number)
-  var previousHex = ethUtil.intToHex(currentNumber-1)
-  delete self.cache[previousHex]
+  if (currentNumber > 0) {
+    var previousHex = ethUtil.intToHex(currentNumber-1)
+    delete self.cache[previousHex]
+  }
 }
 
 


### PR DESCRIPTION
If running `eth_compileSolidity` against `testrpc` it will fail with:

```
assert.js:89
  throw new assert.AssertionError({
  ^
AssertionError: number must be positive
    at Object.exports.intToHex (/Users/alex/Projects/provider-engine/node_modules/ethereumjs-util/index.js:177:3)
    at BlockCacheStrategy.cacheRollOff (/Users/alex/Projects/provider-engine/subproviders/cache.js:238:29)
    at Web3ProviderEngine.<anonymous> (/Users/alex/Projects/provider-engine/subproviders/cache.js:37:27)
    at emitOne (events.js:82:20)
    at Web3ProviderEngine.emit (events.js:169:7)
    at Web3ProviderEngine._setCurrentBlock (/Users/alex/Projects/provider-engine/index.js:172:8)
    at /Users/alex/Projects/provider-engine/index.js:162:12
    at /Users/alex/Projects/provider-engine/index.js:209:5
    at Web3ProviderEngine._inspectResponseForNewBlock (/Users/alex/Projects/provider-engine/index.js:218:12)
    at /Users/alex/Projects/provider-engine/index.js:128:14
```
