### PR TITLE
Add three methods to etherscan subprovider

### DIFF
--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -16,6 +16,15 @@
  * - eth_getTransactionCount
  */
 
+
+/* MISSING
+ * These methods are supported by etherscan
+ * but have not been implemented yet in this provider:
+ *
+ * eth_getTransactionByBlockNumberAndIndex
+ * eth_getStorageAt
+ */
+
 const xhr = process.browser ? require('xhr') : require('request')
 const inherits = require('util').inherits
 const Subprovider = require('./subprovider.js')
@@ -43,6 +52,18 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
         boolean: payload.params[1] }, end)
       return
 
+    case 'eth_getBlockTransactionCountByNumber':
+      etherscanXHR(this.proto, 'proxy', 'eth_getBlockTransactionCountByNumber', {
+        tag: payload.params[0]
+      } end)
+      return
+
+    case 'eth_getTransactionByHash':
+      etherscanXHR(this.proto, 'proxy', 'eth_getTransactionByHash', {
+        txhash: payload.params[0]
+      } end)
+      return
+
     case 'eth_getBalance':
       etherscanXHR(this.proto, 'account', 'balance', {
         address: payload.params[0],
@@ -53,6 +74,10 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
       etherscanXHR(this.proto, 'proxy', 'eth_call', payload.params[0], end)
       return
 
+    case 'eth_getCode':
+      etherscanXHR(this.proto, 'proxy', 'eth_getCode', { address: payload.params[0], tag: payload.params[1] }, end)
+      return
+
     case 'eth_sendRawTransaction':
       etherscanXHR(this.proto, 'proxy', 'eth_sendRawTransaction', { hex: payload.params[0] }, end)
       return
@@ -60,19 +85,19 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
     case 'eth_getTransactionReceipt':
       etherscanXHR(this.proto, 'proxy', 'eth_getTransactionReceipt', { txhash: payload.params[0] }, end)
       return
-      
+
     // note !! this does not support topic filtering yet, it will return all block logs
     case 'eth_getLogs':
       var payloadObject = payload.params[0],
           proto = this.proto,
           txProcessed = 0,
           logs = [];
-      
+
       etherscanXHR(proto, 'proxy', 'eth_getBlockByNumber', {
         tag: payloadObject.toBlock,
         boolean: payload.params[1] }, function(err, blockResult) {
           if(err) return end(err);
-          
+
           for(var transaction in blockResult.transactions){
             etherscanXHR(proto, 'proxy', 'eth_getTransactionReceipt', { txhash: transaction.hash }, function(err, receiptResult) {
               if(!err) logs.concat(receiptResult.logs);
@@ -101,7 +126,7 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
     default:
       next();
       return
-  }  
+  }
 }
 
 function toQueryString(params) {


### PR DESCRIPTION
Methods added:
 - eth_getBlockTransactionCountByNumber
 - eth_getTransactionByHash
 - eth_getCode

We needed `eth_getCode` for Metamask, and I got carried away.

I also added a note about the two remaining [supported methods](http://testnet.etherscan.io/apis) that we are not providing.

Would love thoughts from the original creator of this subprovider @axic