### PR TITLE
Enable homestead featureset in the vm subprovider.

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ethereumjs-block": "^1.2.2",
     "ethereumjs-tx": "^1.1.0",
     "ethereumjs-util": "^4.0.0",
-    "ethereumjs-vm": "^1.2.1",
+    "ethereumjs-vm": "^1.3.0",
     "fake-merkle-patricia-tree": "^1.0.1",
     "isomorphic-fetch": "^2.2.0",
     "request": "^2.67.0",

--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -81,7 +81,9 @@ VmSubprovider.prototype.runVm = function(payload, cb){
   var blockNumber = ethUtil.addHexPrefix(blockData.number.toString('hex'))
 
   // create vm with state lookup intercepted
-  var vm = self.vm = new VM()
+  var vm = self.vm = new VM(null, null, {
+    enableHomestead: true
+  })
 
   if (self.opts.debug) {
     vm.on('step', function (data) {


### PR DESCRIPTION
Enable homestead featureset in vm subprovider.

Note that homestead is both a point in time on the public network as well as an opcode featureset within the vm. This PR asserts that this featureset is enabled by default.