### PR TITLE
add network option for EtherScan subprovider

### DIFF
--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -34,7 +34,7 @@ function EtherscanProvider(opts) {
   this.network = (opts.network !== 'api' && opts.network !== 'testnet') ? 'api' : opts.network
   this.proto = (opts.https || false) ? 'https' : 'http'
   this.payloads = [];
-  this.payloadsPerSecond = 5;
+  this.payloadsPerSecond = isNaN(opts.payloadsPerSecond) ? 5 : opts.payloadsPerSecond;
   
   setInterval(this.handlePayloads, 1000, this);
 }
@@ -131,7 +131,7 @@ function handlePayload(proto, network, payload, next, end){
 }
 
 EtherscanProvider.prototype.handlePayloads = function(self){
-	if(self.payloads.lenght == 0) return;
+	if(self.payloads.length == 0) return;
 	
 	for(var payloadIndex = 0; payloadIndex < self.payloadsPerSecond; payloadIndex++) {
 		var payloadItem = self.payloads.shift()

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -33,67 +33,67 @@ function EtherscanProvider(opts) {
   opts = opts || {}
   this.network = (opts.network !== 'api' && opts.network !== 'testnet') ? 'api' : opts.network
   this.proto = (opts.https || false) ? 'https' : 'http'
+  this.payloads = [];
+  this.payloadsPerSecond = 5;
+  
+  setInterval(this.handlePayloads, 1000, this);
 }
 
-EtherscanProvider.prototype.handleRequest = function(payload, next, end){
-  // console.log("[etherscan] handle request for:", payload.method);
-
+function handlePayload(proto, network, payload, next, end){
   switch(payload.method) {
     case 'eth_blockNumber':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_blockNumber', {}, end)
+      etherscanXHR(true, proto, network, 'proxy', 'eth_blockNumber', {}, end)
       return
 
     case 'eth_getBlockByNumber':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_getBlockByNumber', {
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getBlockByNumber', {
         tag: payload.params[0],
         boolean: payload.params[1] }, end)
       return
 
     case 'eth_getBlockTransactionCountByNumber':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_getBlockTransactionCountByNumber', {
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getBlockTransactionCountByNumber', {
         tag: payload.params[0]
       }, end)
       return
 
     case 'eth_getTransactionByHash':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_getTransactionByHash', {
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getTransactionByHash', {
         txhash: payload.params[0]
       }, end)
       return
 
     case 'eth_getBalance':
-      etherscanXHR(this.proto, this.network, 'account', 'balance', {
+      etherscanXHR(true, proto, network, 'account', 'balance', {
         address: payload.params[0],
         tag: payload.params[1] }, end)
       return
 
     case 'eth_call':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_call', payload.params[0], end)
+      etherscanXHR(true, proto, network, 'proxy', 'eth_call', payload.params[0], end)
       return
 
     case 'eth_sendRawTransaction':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_sendRawTransaction', { hex: payload.params[0] }, end)
+      etherscanXHR(false, proto, network, 'proxy', 'eth_sendRawTransaction', { hex: payload.params[0] }, end)
       return
 
     case 'eth_getTransactionReceipt':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_getTransactionReceipt', { txhash: payload.params[0] }, end)
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getTransactionReceipt', { txhash: payload.params[0] }, end)
       return
 
     // note !! this does not support topic filtering yet, it will return all block logs
     case 'eth_getLogs':
       var payloadObject = payload.params[0],
-          proto = this.proto,
-          network = this.network,
           txProcessed = 0,
           logs = [];
 
-      etherscanXHR(proto, network, 'proxy', 'eth_getBlockByNumber', {
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getBlockByNumber', {
         tag: payloadObject.toBlock,
         boolean: payload.params[1] }, function(err, blockResult) {
           if(err) return end(err);
 
           for(var transaction in blockResult.transactions){
-            etherscanXHR(proto, network, 'proxy', 'eth_getTransactionReceipt', { txhash: transaction.hash }, function(err, receiptResult) {
+            etherscanXHR(true, proto, network, 'proxy', 'eth_getTransactionReceipt', { txhash: transaction.hash }, function(err, receiptResult) {
               if(!err) logs.concat(receiptResult.logs);
               txProcessed += 1;
               if(txProcessed === blockResult.transactions.length) end(null, logs)
@@ -103,21 +103,21 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
       return
 
     case 'eth_getTransactionCount':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_getTransactionCount', {
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getTransactionCount', {
         address: payload.params[0],
         tag: payload.params[1]
       }, end)
       return
 
     case 'eth_getCode':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_getCode', {
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getCode', {
         address: payload.params[0],
         tag: payload.params[1]
       }, end)
       return
 
     case 'eth_getStorageAt':
-      etherscanXHR(this.proto, this.network, 'proxy', 'eth_getStorageAt', {
+      etherscanXHR(true, proto, network, 'proxy', 'eth_getStorageAt', {
         address: payload.params[0],
         position: payload.params[1],
         tag: payload.params[2]
@@ -130,19 +130,34 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
   }
 }
 
+EtherscanProvider.prototype.handlePayloads = function(self){
+	if(self.payloads.lenght == 0) return;
+	
+	for(var payloadIndex = 0; payloadIndex < self.payloadsPerSecond; payloadIndex++) {
+		var payloadItem = self.payloads.shift()
+  		
+		if(typeof payloadItem !== 'undefined')
+			handlePayload(payloadItem.proto, payloadItem.network, payloadItem.payload, payloadItem.next, payloadItem.end)
+	}
+}
+
+EtherscanProvider.prototype.handleRequest = function(payload, next, end){
+  this.payloads.push({proto: this.proto, network: this.network, payload: payload, next: next, end: end});
+}
+
 function toQueryString(params) {
   return Object.keys(params).map(function(k) {
     return encodeURIComponent(k) + '=' + encodeURIComponent(params[k])
   }).join('&')
 }
 
-function etherscanXHR(proto, network, module, action, params, end) {
+function etherscanXHR(useGetMethod, proto, network, module, action, params, end) {
   var uri = proto + '://' + network + '.etherscan.io/api?' + toQueryString({ module: module, action: action }) + '&' + toQueryString(params)
   // console.log('[etherscan] request: ', uri)
-
+	
   xhr({
     uri: uri,
-    method: 'POST',
+    method: useGetMethod ? 'GET' : 'POST',
     headers: {
       'Accept': 'application/json',
       // 'Content-Type': 'application/json',
@@ -152,6 +167,16 @@ function etherscanXHR(proto, network, module, action, params, end) {
     // console.log('[etherscan] response: ', err)
 
     if (err) return end(err)
+	
+	
+	  console.log('[etherscan request]' 
+				  + ' method: ' + useGetMethod
+				  + ' proto: ' + proto
+				  + ' network: ' + network
+				  + ' module: ' + module
+				  + ' action: ' + action
+				  + ' params: ' + params
+				  + ' return body: ' + body);
 
     var data
     try {

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -135,7 +135,7 @@ function handlePayload(proto, network, payload, next, end){
 EtherscanProvider.prototype.handleRequests = function(self){
 	if(self.requests.length == 0) return;
 	
-	console.log('Handling the next ' + self.times + ' of ' + self.requests.length + ' requests');
+	//console.log('Handling the next ' + self.times + ' of ' + self.requests.length + ' requests');
 	
 	for(var requestIndex = 0; requestIndex < self.times; requestIndex++) {
 		var requestItem = self.requests.shift()
@@ -151,9 +151,6 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
   
   if(this.retryFailed)
 	  requestObject.end = function(err, result){
-		  if(err === '403 - Forbidden: Access is denied.')
-			  console.log('forbidden!! retrying..');
-
 		  if(err === '403 - Forbidden: Access is denied.')
 			 self.requests.push(requestObject);
 		  else
@@ -171,7 +168,6 @@ function toQueryString(params) {
 
 function etherscanXHR(useGetMethod, proto, network, module, action, params, end) {
   var uri = proto + '://' + network + '.etherscan.io/api?' + toQueryString({ module: module, action: action }) + '&' + toQueryString(params)
-  // console.log('[etherscan] request: ', uri)
 	
   xhr({
     uri: uri,

--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -191,7 +191,7 @@ function etherscanXHR(useGetMethod, proto, network, module, action, params, end)
 				  + ' params: ' + params
 				  + ' return body: ' + body);*/
 	
-	if(body.indexOf('403 - Forbidden: Access is denied.') > -1)
+    if(body.indexOf('403 - Forbidden: Access is denied.') > -1)
     	return end('403 - Forbidden: Access is denied.')
 	  
     var data


### PR DESCRIPTION
Switch between 'livenet' and morden 'testnet' etherscan apis.

"network" subprovider option:
    "api" => live net (homestead network)
    "testnet" => testnet (morden test network)

Add method support for "GET"/"POST".

Add "retryFailed" for retrying rate limited requests.

Also added in "interval" and "times" for handling the requests in a queue. This way we dont go over rate limiting.

It's hackey, but it works.

@axic would love opinions on this

=D