### PR TITLE
Add `0x` prefix to the LogFilter.address

### DIFF
--- a/subproviders/filters.js
+++ b/subproviders/filters.js
@@ -239,7 +239,7 @@ function LogFilter(opts) {
   const self = this
   self.fromBlock = opts.fromBlock || 'latest'
   self.toBlock = opts.toBlock || 'latest'
-  self.address = opts.address
+  self.address = opts.address ? normalizeHex(opts.address) : opts.address
   self.topics = opts.topics || []
   self.updates = []
   self.allResults = []
@@ -317,6 +317,10 @@ LogFilter.prototype.clearChanges = function(){
 
 
 // util
+
+function normalizeHex(hexString) {
+  return hexString.slice(0, 2) === '0x' ? hexString : '0x'+hexString
+}
 
 function intToHex(value) {
   return '0x'+ethUtil.intToHex(value)


### PR DESCRIPTION
Currently, filters initiated with `address` without `0x` prefix will never match.
In the original geth node implementation, when initiating `address` of the filter, they do like this:
`func HexToAddress(s string) Address    { return BytesToAddress(FromHex(s)) }`
So that there is always `0x` in front of it, even if it came without one.