### PR TITLE
Fix double 0x prefix on filter ids.

### DIFF
--- a/subproviders/filters.js
+++ b/subproviders/filters.js
@@ -323,7 +323,7 @@ function normalizeHex(hexString) {
 }
 
 function intToHex(value) {
-  return '0x'+ethUtil.intToHex(value)
+  return ethUtil.intToHex(value)
 }
 
 function hexToInt(hexString) {


### PR DESCRIPTION
It appears ethereumjs-util was updated to provide the `0x` prefix on its own.