### PR TITLE
Respect `eth_newFilter` requests that have a fromBlock set.

### DIFF
--- a/subproviders/filters.js
+++ b/subproviders/filters.js
@@ -128,7 +128,28 @@ FilterSubprovider.prototype.newFilter = function(opts, cb) {
     self.filters[hexFilterIndex] = filter
     self.filterDestroyHandlers[hexFilterIndex] = destroyHandler
 
-    cb(null, hexFilterIndex)
+    // Fill up the results if this filter has a fromBlock in the past
+    if (opts.fromBlock && hexToInt(opts.fromBlock) <= hexToInt(blockNumber)) {
+      self.emitPayload({
+        method: 'eth_getLogs',
+        params: [{
+          topics: opts.topics,
+          address: opts.address,
+          fromBlock: opts.fromBlock,
+          toBlock: blockNumber
+        }],
+      }, function(err, response){
+        if (err) return cb(err)
+        if (response.error) return cb(response.error)
+
+        Array.prototype.push.apply(filter.allResults, response.result);
+
+        cb(null, hexFilterIndex)
+      })
+
+    } else {
+      cb(null, hexFilterIndex)
+    }
   })
 }
 

--- a/subproviders/filters.js
+++ b/subproviders/filters.js
@@ -142,7 +142,8 @@ FilterSubprovider.prototype.newFilter = function(opts, cb) {
         if (err) return cb(err)
         if (response.error) return cb(response.error)
 
-        Array.prototype.push.apply(filter.allResults, response.result);
+        filter.allResults = filter.allResults.concat(response.result);
+        filter.updates = filter.updates.concat(response.result);
 
         cb(null, hexFilterIndex)
       })


### PR DESCRIPTION
`eth_newFilter` requests allow a `fromBlock`. This PR populates a filter's `allResults` array with previous matching logs when the filter is created.