### PR TITLE
Don't keep node processes open for block polling.

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,6 +144,11 @@ Web3ProviderEngine.prototype._startPolling = function(){
   self._pollIntervalId = setInterval(function() {
     self._fetchLatestBlock()
   }, self._pollingInterval)
+
+  // Tell node that block polling shouldn't keep the process open.
+  if (self._pollIntervalId.unref) {
+    self._pollIntervalId.unref();
+  }
 }
 
 Web3ProviderEngine.prototype._stopPolling = function(){


### PR DESCRIPTION
This solves reported issues with the TestRPC (https://github.com/ethereumjs/testrpc/issues/70, https://github.com/ethereumjs/testrpc/pull/29), as well as issues I'm running into now trying to use the provider engine as a special web3 provider for Truffle.