### PR TITLE
Fix log sanitization

### DIFF
--- a/subproviders/sanitizer.js
+++ b/subproviders/sanitizer.js
@@ -48,14 +48,27 @@ function cloneTxParams(txParams){
         copy[permitted] = txParams[permitted].filter(function(item) {
           return !!item
         }).map(function(item) {
-          return ethUtil.addHexPrefix(item)
+          return sanitize(item)
         })
       } else {
-        copy[permitted] = ethUtil.addHexPrefix(txParams[permitted])
+        copy[permitted] = sanitize(txParams[permitted])
       }
     }
     return copy
   }, {})
 
   return sanitized
+}
+
+function sanitize(value) {
+  switch (value) {
+    case 'latest':
+      return value
+    case 'pending':
+      return value
+    case 'earliest':
+      return value
+    default:
+      return ethUtil.addHexPrefix(value)
+  }
 }

--- a/subproviders/sanitizer.js
+++ b/subproviders/sanitizer.js
@@ -38,6 +38,7 @@ var permitted = [
   'nonce',
   'fromBlock',
   'toBlock',
+  'address',
   'topics',
 ]
 

--- a/subproviders/sanitizer.js
+++ b/subproviders/sanitizer.js
@@ -35,12 +35,24 @@ var permitted = [
   'data',
   'gas',
   'gasPrice',
-  'nonce'
+  'nonce',
+  'fromBlock',
+  'toBlock',
+  'topics',
 ]
+
 function cloneTxParams(txParams){
   var sanitized  =  permitted.reduce(function(copy, permitted) {
     if (permitted in txParams) {
-      copy[permitted] = ethUtil.addHexPrefix(txParams[permitted])
+      if (Array.isArray(txParams[permitted])) {
+        copy[permitted] = txParams[permitted].filter(function(item) {
+          return !!item
+        }).map(function(item) {
+          return ethUtil.addHexPrefix(item)
+        })
+      } else {
+        copy[permitted] = ethUtil.addHexPrefix(txParams[permitted])
+      }
     }
     return copy
   }, {})

--- a/test/subproviders/sanitizer.js
+++ b/test/subproviders/sanitizer.js
@@ -7,7 +7,7 @@ const mockBlock = require('../util/mock_block.json')
 const extend = require('xtend')
 
 test('Sanitizer removes unknown keys', function(t) {
-  t.plan(4)
+  t.plan(6)
 
   var engine = new ProviderEngine()
 
@@ -18,6 +18,8 @@ test('Sanitizer removes unknown keys', function(t) {
     t.ok(!('foo' in payload.params[0]))
     t.equal(payload.params[0].gas, '0x01')
     t.equal(payload.params[0].data, '0x01')
+    t.equal(payload.params[0].topics.length, 2)
+    t.equal(payload.params[0].topics[0], '0x02')
 
     if (payload.method === 'eth_getBlockByNumber') {
       return end(null, mockBlock.result)
@@ -41,9 +43,14 @@ test('Sanitizer removes unknown keys', function(t) {
       foo: 'bar',
       gas: '0x01',
       data: '01',
+      topics: [
+        '0x02',
+        '0x03',
+        null,
+      ],
     }],
   }
   engine.sendAsync(payload, function (err, result) {
     t.equal(result.result.baz, 'bam')
-  })
+ })
 })

--- a/test/subproviders/sanitizer.js
+++ b/test/subproviders/sanitizer.js
@@ -7,7 +7,7 @@ const mockBlock = require('../util/mock_block.json')
 const extend = require('xtend')
 
 test('Sanitizer removes unknown keys', function(t) {
-  t.plan(6)
+  t.plan(7)
 
   var engine = new ProviderEngine()
 
@@ -18,6 +18,7 @@ test('Sanitizer removes unknown keys', function(t) {
     t.ok(!('foo' in payload.params[0]))
     t.equal(payload.params[0].gas, '0x01')
     t.equal(payload.params[0].data, '0x01')
+    t.equal(payload.params[0].fromBlock, 'latest')
     t.equal(payload.params[0].topics.length, 2)
     t.equal(payload.params[0].topics[0], '0x02')
 
@@ -43,6 +44,7 @@ test('Sanitizer removes unknown keys', function(t) {
       foo: 'bar',
       gas: '0x01',
       data: '01',
+      fromBlock: 'latest',
       topics: [
         '0x02',
         '0x03',


### PR DESCRIPTION
Log sanitization was cutting logs out of responses.

This fixes log requests, but leaves me curious if there are other types of requests that this sanitizing subprovider has broken.