### PR TITLE
rename receiptRoot to receiptsRoot

### DIFF
--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ Web3ProviderEngine.prototype._fetchBlock = function(number, cb){
       logsBloom:        ethUtil.toBuffer(data.logsBloom),
       transactionsRoot: ethUtil.toBuffer(data.transactionsRoot),
       stateRoot:        ethUtil.toBuffer(data.stateRoot),
-      receiptRoot:      ethUtil.toBuffer(data.receiptRoot),
+      receiptsRoot:     ethUtil.toBuffer(data.receiptsRoot),
       miner:            ethUtil.toBuffer(data.miner),
       difficulty:       ethUtil.toBuffer(data.difficulty),
       totalDifficulty:  ethUtil.toBuffer(data.totalDifficulty),

--- a/subproviders/vm.js
+++ b/subproviders/vm.js
@@ -131,7 +131,7 @@ function blockFromBlockData(blockData){
   block.header.coinbase = blockData.miner
   block.header.stateRoot = blockData.stateRoot
   block.header.transactionTrie = blockData.transactionsRoot
-  block.header.receiptTrie = blockData.receiptRoot
+  block.header.receiptTrie = blockData.receiptsRoot
   block.header.bloom = blockData.logsBloom
   block.header.difficulty = blockData.difficulty
   block.header.number = blockData.number

--- a/test/util/block.js
+++ b/test/util/block.js
@@ -72,7 +72,7 @@ function createBlock(blockParams, prevBlock, txs) {
     logsBloom:         randomHash(),
     transactionsRoot:  randomHash(),
     stateRoot:         randomHash(),
-    receiptRoot:       randomHash(),
+    receiptsRoot:      randomHash(),
     miner:             randomHash(),
     difficulty:        randomHash(),
     totalDifficulty:   randomHash(),


### PR DESCRIPTION
`receiptsRoot` is the correct term as stated in the [yellowpaper](https://github.com/ethereum/yellowpaper/blob/master/Paper.tex#L309) and was previously [wrongly implemented in geth, but corrected in 1.5.0](https://github.com/ethereum/go-ethereum/issues/3084).