### PR TITLE
eth_compileSolidity returns error as an array instead of a string

### DIFF
--- a/subproviders/solc.js
+++ b/subproviders/solc.js
@@ -36,7 +36,7 @@ SolcSubprovider.prototype._compileSolidity = function(payload, end) {
   if (!output) {
     end('Compilation error')
   } else if (output.errors) {
-    end(output.errors)
+    end(output.errors.join('\n'))
   } else {
     // Select first contract FIXME??
     var contract = output.contracts[Object.keys(output.contracts)[0]];

--- a/test/solc.js
+++ b/test/solc.js
@@ -50,5 +50,25 @@ test('solc test', function(t){
       t.end()
     })
   })
+})
 
+
+test('solc error test', function(t){
+  // handle solc
+  var providerA = injectMetrics(new SolcProvider())
+  // handle block requests
+  var providerB = injectMetrics(new TestBlockProvider())
+
+  var engine = new ProviderEngine()
+  engine.addProvider(providerA)
+  engine.addProvider(providerB)
+
+  var contractSource = 'pragma solidity ^0.4.2; contract error { error() }'
+
+  engine.start()
+  engine.sendAsync(createPayload({ method: 'eth_compileSolidity', params: [ contractSource ] }), function(err, response){
+    t.equal(typeof err, 'string', 'error type is string')
+    engine.stop()
+    t.end()
+  })
 })


### PR DESCRIPTION
This fixes ethereumjs/testrpc#238.