### PR TITLE
Support React Native

### DIFF
--- a/subproviders/rpc.js
+++ b/subproviders/rpc.js
@@ -1,4 +1,4 @@
-const xhr = process.browser ? require('xhr') : require('request')
+const xhr = !process.browser ? require('request') : require('xhr')
 const inherits = require('util').inherits
 const createPayload = require('../util/create-payload.js')
 const Subprovider = require('./subprovider.js')


### PR DESCRIPTION
React Native is not a browser, but [it exposes the XHR API](https://facebook.github.io/react-native/docs/network.html), so if we switch the order we conditionally include request libraries, we will support react native.

Fixes #110