### PR TITLE
Make RPC errors more JSON-RPC spec compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "ethereumjs-util": "^5.1.1",
     "ethereumjs-vm": "^2.0.2",
     "isomorphic-fetch": "^2.2.0",
+    "json-rpc-error": "^2.0.0",
     "request": "^2.67.0",
     "semaphore": "^1.0.3",
     "solc": "^0.4.2",


### PR DESCRIPTION
Uses [npm module json-rpc error](https://www.npmjs.com/package/json-rpc-error) to make the rpc subprovider's errors cannonical with [the JSON RPC spec](http://www.jsonrpc.org/specification#error_object).

Thanks to @MicahZoltu for catching this.

The new result to his sample input:

<img width="397" alt="screen shot 2017-03-06 at 11 04 04 pm" src="https://cloud.githubusercontent.com/assets/542863/23645521/69375c1a-02c1-11e7-9e48-47d0c615944d.png">

Fixes #120 