### PR TITLE
Check for global fetch before requiring ponyfill

### DIFF
--- a/subproviders/fetch.js
+++ b/subproviders/fetch.js
@@ -1,4 +1,4 @@
-const fetch = require('fetch-ponyfill')().fetch
+const fetch = global.fetch || require('fetch-ponyfill')().fetch
 const inherits = require('util').inherits
 const createPayload = require('../util/create-payload.js')
 const Subprovider = require('./subprovider.js')


### PR DESCRIPTION
ponyfill seems to think that the ServiceWorkerGlobalScope does not have fetch and their for uses new XMLHttpRequest() which is not available inside of service workers 