### PR TITLE
Add specific error message for gateway timeouts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 6.3.1
+    version: 7.0.0

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,3 @@
 machine:
   node:
-    version: 7.0.0
+    version: 7.7.3

--- a/subproviders/fetch.js
+++ b/subproviders/fetch.js
@@ -34,6 +34,19 @@ RpcSource.prototype.handleRequest = function(payload, next, end){
       body: JSON.stringify(newPayload),
     }).then((_res) => {
       res = _res
+
+      switch (res.status) {
+
+        case 504:
+          let msg = `Gateway timeout. The request took too long to process. `
+          msg += `This can happen when querying logs over too wide a block range.`
+          err = new Error(msg)
+          throw new JsonRpcError.InternalError(err)
+
+        default:
+          return res.json()
+      }
+
       return res.json()
     }).then((body) => {
       // check for error code

--- a/subproviders/rpc.js
+++ b/subproviders/rpc.js
@@ -32,11 +32,16 @@ RpcSource.prototype.handleRequest = function(payload, next, end){
     rejectUnauthorized: false,
   }, function(err, res, body) {
     if (err) return end(new JsonRpcError.InternalError(err))
-    
+
     // check for error code
     switch (res.statusCode) {
       case 405:
         return end(new JsonRpcError.MethodNotFound())
+      case 504: // Gateway timeout
+        const msg = `Gateway timeout. The request took too long to process. `
+        msg += `This can happen when querying logs over too wide a block range.`
+        const err = new Error(msg)
+        return end(new JsonRpcError.InternalError(err))
       default:
         if (res.statusCode != 200) {
           return end(new JsonRpcError.InternalError(res.body))


### PR DESCRIPTION
When developers query too wide a block range, a 504 gateway timeout is thrown.
This commit ensures a descriptive error is passed back to the application.