### PR TITLE
Fix TestRPC Compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^2.1.2",
     "clone": "^2.0.0",
-    "eth-block-tracker": "^1.0.5",
+    "eth-block-tracker": "^1.0.6",
     "eth-sig-util": "^1.2.1",
     "ethereumjs-block": "^1.2.2",
     "ethereumjs-tx": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^2.1.2",
     "clone": "^2.0.0",
-    "eth-block-tracker": "^1.0.4",
+    "eth-block-tracker": "^1.0.5",
     "eth-sig-util": "^1.2.1",
     "ethereumjs-block": "^1.2.2",
     "ethereumjs-tx": "^1.2.0",


### PR DESCRIPTION
Fixes #134

When querying for a future block by number,
now tolerates a narrow type of "index out of range" errors,
to allow compatibility with current + past versions of TestRPC.