### PR TITLE
Bump block tracker to 1.0.8 to not use es7 features

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^2.1.2",
     "clone": "^2.0.0",
-    "eth-block-tracker": "^1.0.7",
+    "eth-block-tracker": "^1.0.8",
     "eth-sig-util": "^1.2.1",
     "ethereumjs-block": "^1.2.2",
     "ethereumjs-tx": "^1.2.0",


### PR DESCRIPTION
Fixes #127 