### PR TITLE
Bump block tracker to resume polling when error parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web3-provider-engine",
-  "version": "12.0.2",
+  "version": "12.0.3",
   "description": "",
   "repository": "https://github.com/MetaMask/provider-engine",
   "main": "index.js",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "async": "^2.1.2",
     "clone": "^2.0.0",
-    "eth-block-tracker": "^1.0.11",
+    "eth-block-tracker": "^1.0.15",
     "eth-sig-util": "^1.2.1",
     "ethereumjs-block": "^1.2.2",
     "ethereumjs-tx": "^1.2.0",


### PR DESCRIPTION
Includes [this patch](https://github.com/MetaMask/eth-block-tracker/pull/18).