### PR TITLE
Switch personal_sign param order

### DIFF
--- a/subproviders/hooked-wallet.js
+++ b/subproviders/hooked-wallet.js
@@ -124,8 +124,8 @@ HookedWalletSubprovider.prototype.handleRequest = function(payload, next, end){
       return
 
     case 'personal_sign':
-      var address = payload.params[0]
-      var message = payload.params[1]
+      var message = payload.params[0]
+      var address = payload.params[1]
       // non-standard "extraParams" to be appended to our "msgParams" obj
       // good place for metadata
       var extraParams = payload.params[2] || {}

--- a/subproviders/hooked-wallet.js
+++ b/subproviders/hooked-wallet.js
@@ -124,8 +124,32 @@ HookedWalletSubprovider.prototype.handleRequest = function(payload, next, end){
       return
 
     case 'personal_sign':
-      var message = payload.params[0]
-      var address = payload.params[1]
+      const first = payload.params[0]
+      const second = payload.params[1]
+
+      var message, address
+
+      // We initially incorrectly ordered these parameters.
+      // To gracefully respect users who adopted this API early,
+      // we are currently gracefully recovering from the wrong param order
+      // when it is clearly identifiable.
+      //
+      // That means when the first param is definitely an address,
+      // and the second param is definitely not, but is hex.
+      if (resemblesData(second) && resemblesAddress(first)) {
+        let warning = `The eth_personalSign method requires params ordered `
+        warning += `warning, then address. This was previously handled incorrectly, `
+        warning += `and has been corrected automatically. `
+        warning += `Please switch this param order for smooth behavior in the future.`
+        console.warn(warning)
+
+        address = payload.params[0]
+        message = payload.params[1]
+      } else {
+        message = payload.params[0]
+        address = payload.params[1]
+      }
+
       // non-standard "extraParams" to be appended to our "msgParams" obj
       // good place for metadata
       var extraParams = payload.params[2] || {}
@@ -384,6 +408,20 @@ function cloneTxParams(txParams){
 
 function toLowerCase(string){
   return string.toLowerCase()
+}
+
+function resemblesAddress (string) {
+  const fixed = ethUtil.addHexPrefix(string)
+  const isValid = ethUtil.isValidAddress(fixed)
+  return isValid
+}
+
+// Returns true if resembles hex data
+// but definitely not a valid address.
+function resemblesData (string) {
+  const fixed = ethUtil.addHexPrefix(string)
+  const isValidAddress = ethUtil.isValidAddress(fixed)
+  return !isValidAddress && isValidHex(string)
 }
 
 function isValidHex(data) {

--- a/subproviders/hooked-wallet.js
+++ b/subproviders/hooked-wallet.js
@@ -138,7 +138,7 @@ HookedWalletSubprovider.prototype.handleRequest = function(payload, next, end){
       // and the second param is definitely not, but is hex.
       if (resemblesData(second) && resemblesAddress(first)) {
         let warning = `The eth_personalSign method requires params ordered `
-        warning += `warning, then address. This was previously handled incorrectly, `
+        warning += `[message, address]. This was previously handled incorrectly, `
         warning += `and has been corrected automatically. `
         warning += `Please switch this param order for smooth behavior in the future.`
         console.warn(warning)

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -17,7 +17,7 @@ test('tx sig', function(t){
   var privateKey = new Buffer('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
   var address = new Buffer('1234362ef32bcd26d3dd18ca749378213625ba0b', 'hex')
   var addressHex = '0x'+address.toString('hex')
-  
+
   // sign all tx's
   var providerA = injectMetrics(new HookedWalletProvider({
     getAccounts: function(cb){
@@ -80,7 +80,7 @@ test('tx sig', function(t){
 
     // gas price
     t.equal(providerC.getWitnessed('eth_gasPrice').length, 1, 'providerB did see "eth_gasPrice"')
-    t.equal(providerC.getHandled('eth_gasPrice').length, 1, 'providerB did handle "eth_gasPrice"')  
+    t.equal(providerC.getHandled('eth_gasPrice').length, 1, 'providerB did handle "eth_gasPrice"')
 
     // send raw tx
     t.equal(providerC.getWitnessed('eth_sendRawTransaction').length, 1, 'providerC did see "eth_sendRawTransaction"')
@@ -97,7 +97,7 @@ test('no such account', function(t){
 
   var addressHex = '0x1234362ef32bcd26d3dd18ca749378213625ba0b'
   var otherAddressHex = '0x4321362ef32bcd26d3dd18ca749378213625ba0c'
-  
+
   // sign all tx's
   var providerA = injectMetrics(new HookedWalletProvider({
     getAccounts: function(cb){
@@ -153,7 +153,7 @@ test('sign message', function(t){
 
   var privateKey = new Buffer('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
   var addressHex = '0x1234362ef32bcd26d3dd18ca749378213625ba0b'
-  
+
   var message = 'haay wuurl'
   var signature = '0x2c865e6843caf741a694522f86281c9ee86294ade3c8cd1889c9f2c9a24e20802b2b6eb79ba49412661bdbf40245d9b01abb393a843734e5be79b38e7dd408ef1c'
 
@@ -322,6 +322,22 @@ function signatureTest({ testLabel, method, privateKey, addressHex, message, sig
     engine,
     expectedResult: signature,
   })
+
+  // Personal sign is supposed to have params
+  // ordered in this direction, not the other.
+  if (payload.method === 'personal_sign') {
+    var payload = {
+      method: method,
+      params: [message, addressHex],
+    }
+
+    singleRpcTest({
+      testLabel: `sign message ${method} - ${testLabel}`,
+      payload,
+      engine,
+      expectedResult: signature,
+    })
+  }
 }
 
 function recoverTest({ testLabel, method, addressHex, message, signature }) {


### PR DESCRIPTION
Fixes #161 with a graceful fallback strategy which will likely allow most applications to continue working unaffected, except for a new warning alerting them to the situation.

Will be used to fix https://github.com/MetaMask/metamask-plugin/issues/1557

I know it could be controversial to have this graceful fallback (code complexity vs developer sanity), but I think we can afford this tiny bit of bloat, especially if we're about to completely deprecate the current provider for Web3 1.0.