### PR TITLE
Improve sender validation for hooked-wallet-subprovider

### DIFF
--- a/subproviders/hooked-wallet.js
+++ b/subproviders/hooked-wallet.js
@@ -339,7 +339,7 @@ HookedWalletSubprovider.prototype.validateTypedMessage = function(msgParams, cb)
 HookedWalletSubprovider.prototype.validateSender = function(senderAddress, cb){
   const self = this
   // shortcut: undefined sender is invalid
-  if (senderAddress === undefined) return cb(null, false)
+  if (!senderAddress) return cb(null, false)
   self.getAccounts(function(err, accounts){
     if (err) return cb(err)
     var senderIsValid = (accounts.map(toLowerCase).indexOf(senderAddress.toLowerCase()) !== -1)


### PR DESCRIPTION
If params included `from` but it was null instead of undefined, the validation would miss it. Now check for falsiness.