### PR TITLE
Fix requiring 'xhr' outside browser

### DIFF
--- a/subproviders/rpc.js
+++ b/subproviders/rpc.js
@@ -1,4 +1,5 @@
-const xhr = (process.browser || global.XMLHttpRequest) ? require('xhr') : require('request')
+const xhr = (process.browser || (process.browser && global.XMLHttpRequest))
+    ? require('xhr') : require('request')
 const inherits = require('util').inherits
 const createPayload = require('../util/create-payload.js')
 const Subprovider = require('./subprovider.js')


### PR DESCRIPTION
RPC subprovider dosen't work in node. 

to duplicate run in node
```
const Web3 = require('web3');
const ProviderEngine = require('web3-provider-engine');
const RpcSubprovider = require('web3-provider-engine/subproviders/rpc');

const engine = new ProviderEngine();
const web3 = new Web3(engine);
engine.addProvider(new RpcSubprovider({rpcUrl: "http://localhost:8545"}));
engine.start();

web3.eth.getAccounts((error, result) => {
  if(error)
    console.log(error);
  else {
    console.log(result);
  }
});

```
Reason for this is that requiring web3 creates `global.XMLHttpRequest` function so in first line of `rpc.js` `xhr` is required instead `request`