### PR TITLE
fixes unhandeled exception before engine start

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,10 +49,10 @@ function Web3ProviderEngine(opts) {
 
 // public
 
-Web3ProviderEngine.prototype.start = function(){
+Web3ProviderEngine.prototype.start = function(cb){
   const self = this
   // start block polling
-  self._blockTracker.start()
+  self._blockTracker.start().catch(err=>cb(err))
 }
 
 Web3ProviderEngine.prototype.stop = function(){


### PR DESCRIPTION
solves #198 
I am not sure what is the best approach in this case but what I am sure is the exception does not bubble out of the model. So if I import this module there is no way for me to catch the exception. 

The solution I propose is sending a callback function with `start` that gets called in case of an exception and acts accordingly.  
