### PR TITLE
#204 fix caching issue for eth_getStorageAt 

### DIFF
--- a/test/cache-utils.js
+++ b/test/cache-utils.js
@@ -10,3 +10,23 @@ test('cacheIdentifierForPayload for latest block', function (t) {
   t.notEqual(cacheId1, cacheId2, 'cacheIds are unique')
   t.end()
 })
+
+test('blockTagForPayload for different methods', function (t) {
+  const payloads = [
+    {jsonrpc: '2.0', method: 'eth_getBalance', params: ['0x407d73d8a49eeb85d32cf465507dd71d507100c1', '0x1234'], id: 1},
+    {jsonrpc: '2.0', method: 'eth_getCode', params: ['0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b', '0x1234'], id: 1},
+    {jsonrpc: '2.0', method: 'eth_getTransactionCount', params: ['0x407d73d8a49eeb85d32cf465507dd71d507100c1','0x1234'], id: 1},
+    {jsonrpc: '2.0', method: 'eth_getStorageAt', params: ['0x295a70b2de5e3953354a6a8344e616ed314d7251', '0x0', '0x1234'], id: 1},
+    {jsonrpc: '2.0', method: 'eth_call', params: [{to: '0x295a70b2de5e3953354a6a8344e616ed314d7251'}, '0x1234'], id: 1},
+    {jsonrpc: '2.0', method: 'eth_estimateGas', params: [{to: '0x295a70b2de5e3953354a6a8344e616ed314d7251'}, '0x1234'], id: 1},
+    {jsonrpc: '2.0', method: 'eth_getBlockByNumber', params: ['0x1234', true], id: 1},
+  ]
+
+
+  payloads.forEach(function (payload) {
+    const blockTag = cacheUtils.blockTagForPayload(payload)
+    t.isEqual(blockTag, '0x1234', 'block tag for ' + payload.method + ' is correct')
+  })
+
+  t.end()
+})

--- a/test/cache.js
+++ b/test/cache.js
@@ -128,6 +128,24 @@ cacheTest('getBlockForNumber for block 1', [{
   params: ['0x1'],
 }], true)
 
+// storage
+
+cacheTest('getStorageAt for same block should cache', [{
+  method: 'eth_getStorageAt',
+  params: ['0x295a70b2de5e3953354a6a8344e616ed314d7251', '0x0', '0x1234'],
+}, {
+  method: 'eth_getStorageAt',
+  params: ['0x295a70b2de5e3953354a6a8344e616ed314d7251', '0x0', '0x1234'],
+}], true)
+
+cacheTest('getStorageAt for different block should not cache', [{
+  method: 'eth_getStorageAt',
+  params: ['0x295a70b2de5e3953354a6a8344e616ed314d7251', '0x0', '0x1234'],
+}, {
+  method: 'eth_getStorageAt',
+  params: ['0x295a70b2de5e3953354a6a8344e616ed314d7251', '0x0', '0x4321'],
+}], false)
+
 
 // test helper for caching
 // 1. Sets up caching and data provider
@@ -182,7 +200,8 @@ function cacheTest(label, payloads, shouldHitCacheOnSecondRequest){
             input: '0x',
           })
         }
-      }
+      },
+      eth_getStorageAt: '0x00000000000000000000000000000000000000000000000000000000deadbeef',
     }))
     // handle dummy block
     var blockProvider = injectMetrics(new TestBlockProvider())

--- a/util/rpc-cache-utils.js
+++ b/util/rpc-cache-utils.js
@@ -49,11 +49,13 @@ function paramsWithoutBlockTag(payload){
 
 function blockTagParamIndex(payload){
   switch(payload.method) {
+    // blockTag is third param
+    case 'eth_getStorageAt':
+      return 2
     // blockTag is second param
     case 'eth_getBalance':
     case 'eth_getCode':
     case 'eth_getTransactionCount':
-    case 'eth_getStorageAt':
     case 'eth_call':
     case 'eth_estimateGas':
       return 1


### PR DESCRIPTION
I think that issue #204 was caused by using incorrect index for block tag parameter for `eth_getStorageAt`, as a result storage index was used to cache, which led to cache returning same results for different block nubmers. I've fixed issue and added tests for this and a few other methods with block tag parameter.