### PR TITLE
Add prefix to data passed to `signMessage`

### DIFF
--- a/subproviders/hooked-wallet-ethtx.js
+++ b/subproviders/hooked-wallet-ethtx.js
@@ -20,7 +20,7 @@ inherits(HookedWalletEthTxSubprovider, HookedWalletProvider)
 
 function HookedWalletEthTxSubprovider(opts) {
   const self = this
-  
+
   HookedWalletEthTxSubprovider.super_.call(self, opts)
 
   self.signTransaction = function(txData, cb) {
@@ -41,7 +41,8 @@ function HookedWalletEthTxSubprovider(opts) {
   self.signMessage = function(msgParams, cb) {
     opts.getPrivateKey(msgParams.from, function(err, privateKey) {
       if (err) return cb(err)
-      var msgHash = ethUtil.sha3(msgParams.data)
+      var dataBuff = ethUtil.toBuffer(msgParams.data)
+      var msgHash = ethUtil.hashPersonalMessage(dataBuff)
       var sig = ethUtil.ecsign(msgHash, privateKey)
       var serialized = ethUtil.bufferToHex(concatSig(sig.v, sig.r, sig.s))
       cb(null, serialized)

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -155,7 +155,7 @@ test('sign message', function(t){
   var addressHex = '0x1234362ef32bcd26d3dd18ca749378213625ba0b'
 
   var message = 'haay wuurl'
-  var signature = '0x2c865e6843caf741a694522f86281c9ee86294ade3c8cd1889c9f2c9a24e20802b2b6eb79ba49412661bdbf40245d9b01abb393a843734e5be79b38e7dd408ef1c'
+  var signature = '0x68dc980608bceb5f99f691e62c32caccaee05317309015e9454eba1a14c3cd4505d1dd098b8339801239c9bcaac3c4df95569dcf307108b92f68711379be14d81c'
 
   // sign all messages
   var providerA = injectMetrics(new HookedWalletTxProvider({


### PR DESCRIPTION
Currently messages passed to `signMessage` in `HookedWalletEthTx` are currently hashed with `sha3`. There are two standard ways that signers deal with signing messages. They either expect the caller to have prefixed and hashed the message already, or they prefix and hash the message. This provider is introducing a third way: only hashing the message.

This is breaking compatibility with 0x.js (See: https://github.com/0xProject/0x-monorepo/issues/439 and https://github.com/0xProject/0x-monorepo/blob/development/packages/0x.js/src/0x.ts#L256)