### PR TITLE
Make subscriptions actually work.

### DIFF
--- a/subproviders/subscriptions.js
+++ b/subproviders/subscriptions.js
@@ -75,7 +75,7 @@ SubscriptionSubprovider.prototype._notificationHandler = function (id, subscript
 
   // it seems that web3 doesn't expect there to be a separate error event
   // so we must emit null along with the result object
-  self.emit('data', null, {
+  self.engine.emit('data', null, {
     jsonrpc: "2.0",
     method: "eth_subscription",
     params: {


### PR DESCRIPTION
With self.emit() web3 1.0 actually doesn't receive anything (no callbacks listed in object). self.engine.emit() does the right thing.

There's a similar pattern (I think) in filters.js, might be worth looking at

Signed-off-by: Carsten Munk <carsten.munk@zipperglobal.com>