### PR TITLE
Fix check of address existence with checksum addresses

### DIFF
--- a/subproviders/wallet.js
+++ b/subproviders/wallet.js
@@ -13,7 +13,7 @@ function WalletSubprovider (wallet, opts) {
   }
 
   opts.getPrivateKey = function (address, cb) {
-    if (address !== wallet.getAddressString()) {
+    if (address.toLowerCase() !== wallet.getAddressString()) {
       return cb('Account not found')
     }
 


### PR DESCRIPTION
https://github.com/trufflesuite/truffle-hdwallet-provider uses the wallet.js subprovider that checks address equality, it's broken using checksum addresses

This PR fixes the issue