### PR TITLE
Fix: ProviderEngine - unrecognized protocol in HTTP://127.0.0.1:7545

### DIFF
--- a/zero.js
+++ b/zero.js
@@ -116,7 +116,7 @@ function createDataSubprovider(connectionType, opts) {
 function getConnectionType({ rpcUrl }) {
   if (!rpcUrl) return undefined
 
-  const protocol = rpcUrl.split(':')[0]
+  const protocol = rpcUrl.split(':')[0].toLowerCase()
   switch (protocol) {
     case 'http':
     case 'https':


### PR DESCRIPTION
My MetaMask extension stopped loading and showed a white screen. After debugging the background process, the problem was that I had HTTP://127.0.0.1:7545 with upper case HTTP rather than lower case.