### PR TITLE
0-pad signature elements

### DIFF
--- a/subproviders/hooked-wallet-ethtx.js
+++ b/subproviders/hooked-wallet-ethtx.js
@@ -71,8 +71,8 @@ function concatSig(v, r, s) {
   r = ethUtil.fromSigned(r)
   s = ethUtil.fromSigned(s)
   v = ethUtil.bufferToInt(v)
-  r = ethUtil.toUnsigned(r).toString('hex')
-  s = ethUtil.toUnsigned(s).toString('hex')
+  r = ethUtil.toUnsigned(r).toString('hex').padStart(64, 0)
+  s = ethUtil.toUnsigned(s).toString('hex').padStart(64, 0)
   v = ethUtil.stripHexPrefix(ethUtil.intToHex(v))
   return ethUtil.addHexPrefix(r.concat(s, v).toString("hex"))
 }


### PR DESCRIPTION
When concatenating signatures, R and S are converted to signed then unsigned integers. In the process, if either R or S started with a 0 byte, it gets dropped. The result is that while concatSig should always return a hex encoded 65 byte string, in some circumstances it can end up shorter.

I apologize for not providing a test case. The only way I've found to reproduce this involves signing a particular message with a key that I need to keep private, and concatSig is not directly exported, so I can't test it directly.