### PR TITLE
feat: add start/stop events and dummy methods on Subprovider

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,12 +57,21 @@ Web3ProviderEngine.prototype.start = function(cb = noop){
   const self = this
   // start block polling
   self._blockTracker.start().then(cb).catch(cb)
+  self._running = true
+  self.emit('start')
 }
 
 Web3ProviderEngine.prototype.stop = function(){
   const self = this
   // stop block polling
   self._blockTracker.stop()
+  self._running = false
+  self.emit('stop')
+}
+
+Web3ProviderEngine.prototype.isRunning = function(){
+  const self = this
+  return self._running
 }
 
 Web3ProviderEngine.prototype.addProvider = function(source){

--- a/subproviders/subprovider.js
+++ b/subproviders/subprovider.js
@@ -15,6 +15,14 @@ SubProvider.prototype.setEngine = function(engine) {
   engine.on('block', function(block) {
     self.currentBlock = block
   })
+
+  engine.on('start', function () {
+    self.start()
+  })
+
+  engine.on('stop', function () {
+    self.stop()
+  })
 }
 
 SubProvider.prototype.handleRequest = function(payload, next, end) {
@@ -24,4 +32,11 @@ SubProvider.prototype.handleRequest = function(payload, next, end) {
 SubProvider.prototype.emitPayload = function(payload, cb){
   const self = this
   self.engine.sendAsync(createPayload(payload), cb)
+}
+
+// dummies for overriding
+SubProvider.prototype.stop = function () {
+}
+
+SubProvider.prototype.start = function () {
 }


### PR DESCRIPTION
useful for creating / clearing intervals/timeouts, which seems to be tricky to do correctly in subproviders