### PR TITLE
Update Minimum Request Version to Mitigate Security Vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "json-stable-stringify": "^1.0.1",
     "promise-to-callback": "^1.0.0",
     "readable-stream": "^2.2.9",
-    "request": "^2.67.0",
+    "request": "^2.85.0",
     "semaphore": "^1.0.3",
     "tape": "^4.4.0",
     "ws": "^5.1.1",


### PR DESCRIPTION
While this repository doesn't have a `package-lock.json` and developers can choose which version of `request` to use, there is a CVE vulnerability ([CVE-2018-3728](https://nvd.nist.gov/vuln/detail/CVE-2018-3728)) in `request->hawk->hoek`. `request@2.85.0` mitigates this by updating `hawk` which has a version of `hoek` that no longer has the vulnerability.

This PR bumps the minimum version of request to `2.85.0` so other repos cannot download a lesser, vulnerable version.