### PR TITLE
Fix never-ending Request Bug

### DIFF
--- a/subproviders/rpc.js
+++ b/subproviders/rpc.js
@@ -30,6 +30,7 @@ RpcSource.prototype.handleRequest = function(payload, next, end){
     },
     body: JSON.stringify(newPayload),
     rejectUnauthorized: false,
+    timeout: 20000,
   }, function(err, res, body) {
     if (err) return end(new JsonRpcError.InternalError(err))
 


### PR DESCRIPTION
We have been observing some strange behavior where sometimes our provider (setup with a single subprovider: RPCSubprovider) will stop sending JSON RPC requests intermittently.

It turns out, sometimes Infura (and other Ethereum nodes too) will accept a JSON RPC request, but never return a response. If this happens, the XHR request within `RPCSubprovider` will hang indefinitely, and because it never returns, no further requests will be sent from the provider.

This PR adds the `timeout` parameter to the XHR request. This causes the request to return an error after the timeout passes (here set to 20sec, the same as the [default linux kernal tcp socket open timeout](http://www.sekuda.com/overriding_the_default_linux_kernel_20_second_tcp_socket_connect_timeout)). 

With this timeout in place, the provider is guaranteed to continue sending JSON RPC requests, even if a request to the backing node never receives a response.