### PR TITLE
add removeProvider and addProvider with index

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,10 +65,21 @@ Web3ProviderEngine.prototype.stop = function(){
   self._blockTracker.stop()
 }
 
-Web3ProviderEngine.prototype.addProvider = function(source){
+Web3ProviderEngine.prototype.addProvider = function(source, index){
   const self = this
-  self._providers.push(source)
+  if (typeof index === 'number') {
+    self._providers.splice(index, 0, source)
+  } else {
+    self._providers.push(source)
+  }
   source.setEngine(this)
+}
+
+Web3ProviderEngine.prototype.removeProvider = function(source){
+  const self = this
+  const index = self._providers.indexOf(source)
+  if (index < 0) throw new Error('Provider not found.')
+  self._providers.splice(index, 1)
 }
 
 Web3ProviderEngine.prototype.send = function(payload){

--- a/subproviders/subprovider.js
+++ b/subproviders/subprovider.js
@@ -11,10 +11,12 @@ function SubProvider() {
 
 SubProvider.prototype.setEngine = function(engine) {
   const self = this
+  if (self._ranSetEngine) return
   self.engine = engine
   engine.on('block', function(block) {
     self.currentBlock = block
   })
+  self._ranSetEngine = true
 }
 
 SubProvider.prototype.handleRequest = function(payload, next, end) {

--- a/subproviders/subprovider.js
+++ b/subproviders/subprovider.js
@@ -11,12 +11,11 @@ function SubProvider() {
 
 SubProvider.prototype.setEngine = function(engine) {
   const self = this
-  if (self._ranSetEngine) return
+  if (self.engine) return
   self.engine = engine
   engine.on('block', function(block) {
     self.currentBlock = block
   })
-  self._ranSetEngine = true
 }
 
 SubProvider.prototype.handleRequest = function(payload, next, end) {

--- a/test/basic.js
+++ b/test/basic.js
@@ -43,3 +43,30 @@ test('fallthrough test', function(t){
   })
 
 })
+
+test('add provider at index', function(t){
+  var providerA = new PassthroughProvider()
+  var providerB = new PassthroughProvider()
+  var providerC = new PassthroughProvider()
+  var engine = new ProviderEngine()
+  engine.addProvider(providerA)
+  engine.addProvider(providerB)
+  engine.addProvider(providerC, 1)
+
+  t.deepEqual(engine._providers, [providerA, providerC, providerB])
+  t.end()
+})
+
+test('remove provider', function(t){
+  var providerA = new PassthroughProvider()
+  var providerB = new PassthroughProvider()
+  var providerC = new PassthroughProvider()
+  var engine = new ProviderEngine()
+  engine.addProvider(providerA)
+  engine.addProvider(providerB)
+  engine.addProvider(providerC)
+  engine.removeProvider(providerB)
+
+  t.deepEqual(engine._providers, [providerA, providerC])
+  t.end()
+})


### PR DESCRIPTION
This allows swapping out different subproviders during the lifetime of a single provider engine. Maybe this would be useful for someone else out there. If there's anything else needed to make this work as desired / more merge-friendly, please let me know.