### PR TITLE
eth_getFilterLogs returns [] when given non log id

### DIFF
--- a/subproviders/filters.js
+++ b/subproviders/filters.js
@@ -195,7 +195,7 @@ FilterSubprovider.prototype.getFilterLogs = function(hexFilterId, cb) {
       cb(null, res.result)
     })
   } else {
-    var results = filter.getAllResults()
+    var results = []
     cb(null, results)
   }
 }


### PR DESCRIPTION
Prior to this change if you call eth_getFilterLogs with a filter ID that
is valid but does not match a log filter, it attempts to return all
results from the filter in question anyway. Since block filters don't
implement this functionality, this caused a crash when the ID matched
that of a block filter. This is causing problems for some ganache users,
as indicated in trufflesuite/ganache#879.