### PR TITLE
Fix randomly failing filter and subscription tests #189

### DIFF
--- a/test/util/block.js
+++ b/test/util/block.js
@@ -118,7 +118,7 @@ function incrementHex(hexString){
 }
 
 function randomHash(){
-  return ethUtil.intToHex(Math.floor(Math.random()*Number.MAX_SAFE_INTEGER))
+  return ethUtil.bufferToHex(ethUtil.toBuffer(Math.floor(Math.random()*Number.MAX_SAFE_INTEGER)))
 }
 
 function stripLeadingZeroes (hexString) {


### PR DESCRIPTION
Running `npm run test` randomly failed 1 or 2 tests. Upon further research the failing tests were related to filters and subscriptions #189.

~~~~javascript
not ok 273 correct result
  ---
    operator: equal
    expected: '0x5ea279b714bc7'
    actual:   '0x05ea279b714bc7'
    at: filterChangesOne (/Users/gislik/Code/provider-engine/test/filters.js:18:7)
    stack: |-
      Error: correct result
          at Test.assert [as _assert] (/Users/gislik/Code/provider-engine/node_modules/tape/lib/test.js:224:54)
          at Test.bound [as _assert] (/Users/gislik/Code/provider-engine/node_modules/tape/lib/test.js:76:32)
          at Test.equal (/Users/gislik/Code/provider-engine/node_modules/tape/lib/test.js:384:10)
          at Test.bound [as equal] (/Users/gislik/Code/provider-engine/node_modules/tape/lib/test.js:76:32)
          at filterChangesOne (/Users/gislik/Code/provider-engine/test/filters.js:18:7)
          at /Users/gislik/Code/provider-engine/test/filters.js:282:9
          at /Users/gislik/Code/provider-engine/index.js:152:9
          at /Users/gislik/Code/provider-engine/node_modules/async/internal/once.js:12:16
          at replenish (/Users/gislik/Code/provider-engine/node_modules/async/internal/eachOfLimit.js:61:25)
          at /Users/gislik/Code/provider-engine/node_modules/async/internal/eachOfLimit.js:71:9
  ...
~~~~

The current implementation of `randomHash()` from the test suite generates a random number between 0x0 and `0x1FFFFFFFFFFFFF`. 

The problem appears when the random number is e.g. `0x0DA6F8F568D599` which is returned from `randomHash()` as `0xDA6F8F568D599` (without padded 0) but is formatted as `0x0DA6F8F568D599` on its way through the `SubscriptionProvider` - and thus the comparison.

The fix uses the same formatting for the test suite as the provider.