### PR TITLE
Adding mixHash to newHeads subscription output

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,6 +173,7 @@ function toBufferBlock (jsonBlock) {
     hash:             ethUtil.toBuffer(jsonBlock.hash),
     parentHash:       ethUtil.toBuffer(jsonBlock.parentHash),
     nonce:            ethUtil.toBuffer(jsonBlock.nonce),
+    mixHash:          ethUtil.toBuffer(jsonBlock.mixHash),
     sha3Uncles:       ethUtil.toBuffer(jsonBlock.sha3Uncles),
     logsBloom:        ethUtil.toBuffer(jsonBlock.logsBloom),
     transactionsRoot: ethUtil.toBuffer(jsonBlock.transactionsRoot),

--- a/subproviders/subscriptions.js
+++ b/subproviders/subscriptions.js
@@ -118,6 +118,7 @@ SubscriptionSubprovider.prototype._notificationResultFromBlock = function(block)
     gasLimit: from.intToQuantityHex(utils.bufferToInt(block.gasLimit)),
     gasUsed: from.intToQuantityHex(utils.bufferToInt(block.gasUsed)),
     nonce: block.nonce ? utils.bufferToHex(block.nonce): null,
+    mixHash: utils.bufferToHex(block.mixHash),
     timestamp: from.intToQuantityHex(utils.bufferToInt(block.timestamp)),
     extraData: utils.bufferToHex(block.extraData)
   }

--- a/test/util/block.js
+++ b/test/util/block.js
@@ -95,6 +95,7 @@ function createBlock(blockParams, prevBlock, txs) {
     hash:              randomHash(),
     parentHash:        prevBlock ? prevBlock.hash : randomHash(),
     nonce:             randomHash(),
+    mixHash:           randomHash(),
     sha3Uncles:        randomHash(),
     logsBloom:         randomHash(),
     transactionsRoot:  randomHash(),


### PR DESCRIPTION
The golang implementation (geth) has, since v1.5.0, relied on the mixHash field to be present in the JSON representation of a block to calculate and verify the block hash.

See https://github.com/ethereum/go-ethereum/issues/3230 for the discussion.

Eventhough this was not specified in the Ethereum [JSON-RPC protocol](https://github.com/ethereum/wiki/wiki/JSON-RPC) this was recognized (https://github.com/paritytech/parity-ethereum/issues/3148) by the Parity team and subsequently implemented and merged (https://github.com/paritytech/parity-ethereum/pull/3169) into the Parity client.

When the websocket subprovider was implemented #189 it omitted the mixHash which results in the following error when using geth's ethclient.

    missing required field 'mixHash' for Header

This pull request adds the mixHash to the JSON output.

