### PR TITLE
Refactor buffer constructor

### DIFF
--- a/subproviders/nonce-tracker.js
+++ b/subproviders/nonce-tracker.js
@@ -57,8 +57,8 @@ NonceTrackerSubprovider.prototype.handleRequest = function(payload, next, end){
         // parse raw tx
         var rawTx = payload.params[0]
         var stripped = ethUtil.stripHexPrefix(rawTx)
-        var rawData = new Buffer(ethUtil.stripHexPrefix(rawTx), 'hex')
-        var tx = new Transaction(new Buffer(ethUtil.stripHexPrefix(rawTx), 'hex'))
+        var rawData = Buffer.from(ethUtil.stripHexPrefix(rawTx), 'hex')
+        var tx = new Transaction(Buffer.from(ethUtil.stripHexPrefix(rawTx), 'hex'))
         // extract address
         var address = '0x'+tx.getSenderAddress().toString('hex').toLowerCase()
         // extract nonce and increment

--- a/test/nonce.js
+++ b/test/nonce.js
@@ -13,8 +13,8 @@ const injectMetrics = require('./util/inject-metrics')
 test('basic nonce tracking', function(t){
   t.plan(11)
 
-  var privateKey = new Buffer('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
-  var address = new Buffer('1234362ef32bcd26d3dd18ca749378213625ba0b', 'hex')
+  var privateKey = Buffer.from('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
+  var address = Buffer.from('1234362ef32bcd26d3dd18ca749378213625ba0b', 'hex')
   var addressHex = '0x'+address.toString('hex')
   
   // sign all tx's
@@ -96,8 +96,8 @@ test('basic nonce tracking', function(t){
 test('nonce tracking - on error', function(t){
   t.plan(11)
 
-  var privateKey = new Buffer('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
-  var address = new Buffer('1234362ef32bcd26d3dd18ca749378213625ba0b', 'hex')
+  var privateKey = Buffer.from('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
+  var address = Buffer.from('1234362ef32bcd26d3dd18ca749378213625ba0b', 'hex')
   var addressHex = '0x'+address.toString('hex')
   
   // sign all tx's

--- a/test/wallet.js
+++ b/test/wallet.js
@@ -14,8 +14,8 @@ const injectMetrics = require('./util/inject-metrics')
 test('tx sig', function(t){
   t.plan(12)
 
-  var privateKey = new Buffer('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
-  var address = new Buffer('1234362ef32bcd26d3dd18ca749378213625ba0b', 'hex')
+  var privateKey = Buffer.from('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
+  var address = Buffer.from('1234362ef32bcd26d3dd18ca749378213625ba0b', 'hex')
   var addressHex = '0x'+address.toString('hex')
 
   // sign all tx's
@@ -151,7 +151,7 @@ test('no such account', function(t){
 test('sign message', function(t){
   t.plan(3)
 
-  var privateKey = new Buffer('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
+  var privateKey = Buffer.from('cccd8f4d88de61f92f3747e4a9604a0395e6ad5138add4bec4a2ddf231ee24f9', 'hex')
   var addressHex = '0x1234362ef32bcd26d3dd18ca749378213625ba0b'
 
   var message = 'haay wuurl'
@@ -206,7 +206,7 @@ signatureTest({
   message: '0x68656c6c6f20776f726c64',
   signature: '0xce909e8ea6851bc36c007a0072d0524b07a3ff8d4e623aca4c71ca8e57250c4d0a3fc38fa8fbaaa81ead4b9f6bd03356b6f8bf18bccad167d78891636e1d69561b',
   addressHex: '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',
-  privateKey: new Buffer('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
+  privateKey: Buffer.from('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
 })
 
 signatureTest({
@@ -216,7 +216,7 @@ signatureTest({
   message: '0x0cc175b9c0f1b6a831c399e26977266192eb5ffee6ae2fec3ad71c777531578f',
   signature: '0x9ff8350cc7354b80740a3580d0e0fd4f1f02062040bc06b893d70906f8728bb5163837fd376bf77ce03b55e9bd092b32af60e86abce48f7b8d3539988ee5a9be1c',
   addressHex: '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',
-  privateKey: new Buffer('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
+  privateKey: Buffer.from('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
 })
 
 signatureTest({
@@ -228,7 +228,7 @@ signatureTest({
   message: '0x0cc175b9c0f1b6a831c399e26977266192eb5ffee6ae2fec3ad71c777531578f',
   signature: '0xa2870db1d0c26ef93c7b72d2a0830fa6b841e0593f7186bc6c7cc317af8cf3a42fda03bd589a49949aa05db83300cdb553116274518dbe9d90c65d0213f4af491b',
   addressHex: '0xe0da1edcea030875cd0f199d96eb70f6ab78faf2',
-  privateKey: new Buffer('4545454545454545454545454545454545454545454545454545454545454545', 'hex'),
+  privateKey: Buffer.from('4545454545454545454545454545454545454545454545454545454545454545', 'hex'),
 })
 
 recoverTest({
@@ -262,7 +262,7 @@ signatureTest({
   ],
   signature: '0xb2c9c7bdaee2cc73f318647c3f6e24792fca86a9f2736d9e7537e64c503545392313ebbbcb623c828fd8f99fd1fb48f8f4da8cb1d1a924e28b21de018c826e181c',
   addressHex: '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',
-  privateKey: new Buffer('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
+  privateKey: Buffer.from('6969696969696969696969696969696969696969696969696969696969696969', 'hex'),
 })
 
 test('sender validation, with mixed-case', function(t){

--- a/util/rpc-hex-encoding.js
+++ b/util/rpc-hex-encoding.js
@@ -29,6 +29,6 @@ function quantityHexToInt(prefixedQuantityHex) {
     if (!isEven) {
         quantityHex = '0' + quantityHex
     }
-    var buf = new Buffer(quantityHex, 'hex')
+    var buf = Buffer.from(quantityHex, 'hex')
     return ethUtil.bufferToInt(buf)
 }


### PR DESCRIPTION
This PR replaces all `new Buffer` with `Buffer.from`. We should not use Buffer constructor which is deprecated and unsafe.

The behavior of new Buffer() is different depending on the type of the first argument, security and reliability issues can be inadvertently introduced into applications when argument validation or Buffer initialization is not performed.

To make the creation of Buffer instances more reliable and less error-prone, the various forms of the new Buffer() constructor have been deprecated and replaced by separate Buffer.from(), Buffer.alloc(), and Buffer.allocUnsafe() methods.

Check this out: https://nodejs.org/api/buffer.html#buffer_buffer_from_buffer_alloc_and_buffer_allocunsafe
https://github.com/nodejs/Release#end-of-life-releases