### PR TITLE
update 'origin' setting in websocket subprovider to follow final WebSocket spec

### DIFF
--- a/subproviders/websocket.js
+++ b/subproviders/websocket.js
@@ -142,7 +142,7 @@ class WebsocketSubprovider
 
   _openSocket() {
     this._log('Opening socket...')
-    this._socket = new WebSocket(this._url, null, {origin: this._origin})
+    this._socket = new WebSocket(this._url, null, this._origin ? {headers:{origin: this._origin}} : {})
     this._socket.addEventListener('close', this._handleSocketClose)
     this._socket.addEventListener('message', this._handleSocketMessage)
     this._socket.addEventListener('open', this._handleSocketOpen)


### PR DESCRIPTION
This came out of usage within a React Native app, which seems to be stricter about which spec it wants you to follow.

You should test this in all major browsers before merging, I haven't ;)