### PR TITLE
Block difficulty error on kovan

### DIFF
--- a/subproviders/subscriptions.js
+++ b/subproviders/subscriptions.js
@@ -104,6 +104,10 @@ SubscriptionSubprovider.prototype._notificationHandler = function (hexId, subscr
 }
 
 SubscriptionSubprovider.prototype._notificationResultFromBlock = function(block) {
+  const difficulty = new utils.BN(utils.bufferToHex(block.difficulty), 16);
+  if (difficulty.bitLength() > 53) {
+    block.difficulty = 0;
+  }
   return {
     hash: utils.bufferToHex(block.hash),
     parentHash: utils.bufferToHex(block.parentHash),

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -20,6 +20,31 @@ subscriptionTest('basic block subscription', {
   }
 )
 
+subscriptionTest('basic block subscription - difficulty bug', {
+    method: 'eth_subscribe',
+    params: ['newHeads']
+  },
+  function afterInstall(t, testMeta, response, cb){
+    testMeta.blockProvider.nextBlock({
+      difficulty: "0x1"
+    })
+    cb()
+  },
+  function subscriptionChangesOne(t, testMeta, response, cb) {
+    let returnedDifficulty = response.params.result.difficulty
+    t.equal(returnedDifficulty, '0x1', 'correct result')
+    testMeta.blockProvider.nextBlock({
+      difficulty: "0xffffffffffffffffffffffffffffffff"
+    })
+    cb()
+  },
+  function subscriptionChangesTwo(t, testMeta, response, cb) {
+    let returnedDifficulty = response.params.result.difficulty
+    t.equal(returnedDifficulty, '0x0', 'correct result')
+    cb()
+  }
+)
+
 subscriptionTest('log subscription - basic', {
     method: 'eth_subscribe',
     params: ['logs', {


### PR DESCRIPTION
Found an issue when using the subscription subprovider on kovan network. As kovan is poa, its difficulty is returned as `0xff..ff|c|d|e|f` for some reason which breaks the notification result. This fix will change  `block.difficulty` to `0` in event of it being greater than 53 bits. 

[Gif demonstrating issue](https://i.imgur.com/qQQeUhv.gifv)