### PR TITLE
Fix issue with parsing large quantities in blocks

### DIFF
--- a/subproviders/subscriptions.js
+++ b/subproviders/subscriptions.js
@@ -113,13 +113,13 @@ SubscriptionSubprovider.prototype._notificationResultFromBlock = function(block)
     transactionsRoot: utils.bufferToHex(block.transactionsRoot),
     receiptsRoot: utils.bufferToHex(block.receiptsRoot),
     logsBloom: utils.bufferToHex(block.logsBloom),
-    difficulty: from.intToQuantityHex(utils.bufferToInt(block.difficulty)),
-    number: from.intToQuantityHex(utils.bufferToInt(block.number)),
-    gasLimit: from.intToQuantityHex(utils.bufferToInt(block.gasLimit)),
-    gasUsed: from.intToQuantityHex(utils.bufferToInt(block.gasUsed)),
+    difficulty: from.bufferToQuantityHex(block.difficulty),
+    number: from.bufferToQuantityHex(block.number),
+    gasLimit: from.bufferToQuantityHex(block.gasLimit),
+    gasUsed: from.bufferToQuantityHex(block.gasUsed),
     nonce: block.nonce ? utils.bufferToHex(block.nonce): null,
     mixHash: utils.bufferToHex(block.mixHash),
-    timestamp: from.intToQuantityHex(utils.bufferToInt(block.timestamp)),
+    timestamp: from.bufferToQuantityHex(block.timestamp),
     extraData: utils.bufferToHex(block.extraData)
   }
 }

--- a/test/subscriptions.js
+++ b/test/subscriptions.js
@@ -146,6 +146,26 @@ subscriptionTest('log subscription - wildcard logic', {
   }
 )
 
+subscriptionTest('block subscription - parsing large difficulty', {
+    method: 'eth_subscribe',
+    params: ['newHeads']
+  },
+  function afterInstall(t, testMeta, response, cb) {
+    testMeta.blockProvider.nextBlock({
+      gasLimit: '0x01',
+      difficulty: '0xfffffffffffffffffffffffffffffffe'
+    })
+    cb()
+  },
+  function subscriptionChangesOne(t, testMeta, response, cb) {
+    var returnedDifficulty = response.params.result.difficulty
+    var returnedGasLimit = response.params.result.gasLimit
+    t.equal(returnedDifficulty, '0xfffffffffffffffffffffffffffffffe', 'correct result')
+    t.equal(returnedGasLimit, '0x1', 'correct result')
+    cb()
+  }
+)
+
 function subscriptionTest(label, subscriptionPayload, afterInstall, subscriptionChangesOne, subscriptionChangesTwo) {
   let testMeta = {}
   let t = test('subscriptions - '+label, function(t) {

--- a/util/rpc-hex-encoding.js
+++ b/util/rpc-hex-encoding.js
@@ -2,18 +2,26 @@ const ethUtil = require('ethereumjs-util')
 const assert = require('./assert.js')
 
 module.exports = {
+  bufferToQuantityHex: bufferToQuantityHex,
   intToQuantityHex: intToQuantityHex,
   quantityHexToInt: quantityHexToInt,
 }
 
 /*
  * As per https://github.com/ethereum/wiki/wiki/JSON-RPC#hex-value-encoding
- * Quanities should be represented by the most compact hex representation possible
+ * Quantities should be represented by the most compact hex representation possible
  * This means that no leading zeroes are allowed. There helpers make it easy
  * to convert to and from integers and their compact hex representation
  */
 
-function intToQuantityHex(n){
+function bufferToQuantityHex(buffer) {
+    buffer = ethUtil.toBuffer(buffer);
+    var hex = buffer.toString('hex');
+    var trimmed = ethUtil.unpad(hex);
+    return ethUtil.addHexPrefix(trimmed);
+}
+
+function intToQuantityHex(n) {
     assert(typeof n === 'number' && n === Math.floor(n), 'intToQuantityHex arg must be an integer')
     var nHex = ethUtil.toBuffer(n).toString('hex')
     if (nHex[0] === '0') {


### PR DESCRIPTION
I was having trouble subscribing to new blocks on Kovan, when I discovered Kovan's difficulty is too large to be parsed into a Number in javascript. It seems the reason it's parsed into a number in the first place is to basically format it back into hex.

This changes all quantity values to use a new utility method that safely converts from Buffer to a quantity-style hex string.