### PR TITLE
Always use lower case addresses in getPrivateKey comparison

### DIFF
--- a/subproviders/wallet.js
+++ b/subproviders/wallet.js
@@ -13,7 +13,7 @@ function WalletSubprovider (wallet, opts) {
   }
 
   opts.getPrivateKey = function (address, cb) {
-    if (address !== wallet.getAddressString()) {
+    if (address.toLowerCase() !== wallet.getAddressString()) {
       return cb('Account not found')
     }
 


### PR DESCRIPTION
Fixes #294.

Most of the code considers the account list with `toLowerCase`. This changes ensures it happens in `wallet.js` too.