### PR TITLE
Fix invalid WebSocket constructor parameter

### DIFF
--- a/subproviders/websocket.js
+++ b/subproviders/websocket.js
@@ -142,7 +142,7 @@ class WebsocketSubprovider
 
   _openSocket() {
     this._log('Opening socket...')
-    this._socket = new WebSocket(this._url, null, {origin: this._origin})
+    this._socket = new WebSocket(this._url, [], {origin: this._origin})
     this._socket.addEventListener('close', this._handleSocketClose)
     this._socket.addEventListener('message', this._handleSocketMessage)
     this._socket.addEventListener('open', this._handleSocketOpen)


### PR DESCRIPTION
Resolves #292 

📓 Overview:

- added correct protocols parameter to the WebSocket constructor, as specified in the WebSocket constructor reference: https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket