### PR TITLE
Handle testrpc revert

### DIFF
--- a/subproviders/nonce-tracker.js
+++ b/subproviders/nonce-tracker.js
@@ -75,6 +75,12 @@ NonceTrackerSubprovider.prototype.handleRequest = function(payload, next, end){
       })
       return
 
+   // Clear cache on a testrpc revert
+   case 'evm_revert':
+      self.nonceCache = {}
+      next()
+      return
+
     default:
       next()
       return

--- a/subproviders/nonce-tracker.js
+++ b/subproviders/nonce-tracker.js
@@ -8,9 +8,10 @@ module.exports = NonceTrackerSubprovider
 
 // handles the following RPC methods:
 //   eth_getTransactionCount (pending only)
+//
 // observes the following RPC methods:
 //   eth_sendRawTransaction
-
+//   evm_revert (to clear the nonce cache)
 
 inherits(NonceTrackerSubprovider, Subprovider)
 


### PR DESCRIPTION
I'm experience some problems using the provider for testing in a local ganache-cli.

I believe the issue is because the `NonceTrackerSubprovider` is caching the nonce even after reverting the state of a the local ganache.

Reverting the state in a local testrpc is very common thing to do in order to make the test repeatable, and to avoid tests influence each other.

Clearing the cache, make sure, we get the new nonce from the new state of the blockchain.