### PR TITLE
Fix for mutating in-flight cache responses

### DIFF
--- a/subproviders/inflight-cache.js
+++ b/subproviders/inflight-cache.js
@@ -1,5 +1,6 @@
 const cacheIdentifierForPayload = require('../util/rpc-cache-utils.js').cacheIdentifierForPayload
 const Subprovider = require('./subprovider.js')
+const clone = require('clone')
 
 
 class InflightCacheSubprovider extends Subprovider {
@@ -30,7 +31,7 @@ class InflightCacheSubprovider extends Subprovider {
       next((err, result, cb) => {
         // complete inflight for cacheId
         delete this.inflightRequests[cacheId]
-        activeRequestHandlers.forEach((handler) => handler(err, Object.assign({}, result)))
+        activeRequestHandlers.forEach((handler) => handler(err, clone(result)))
         cb(err, result)
       })
 

--- a/subproviders/inflight-cache.js
+++ b/subproviders/inflight-cache.js
@@ -30,7 +30,7 @@ class InflightCacheSubprovider extends Subprovider {
       next((err, result, cb) => {
         // complete inflight for cacheId
         delete this.inflightRequests[cacheId]
-        activeRequestHandlers.forEach((handler) => handler(err, result))
+        activeRequestHandlers.forEach((handler) => handler(err, Object.assign({}, result)))
         cb(err, result)
       })
 
@@ -44,4 +44,3 @@ class InflightCacheSubprovider extends Subprovider {
 }
 
 module.exports = InflightCacheSubprovider
-


### PR DESCRIPTION
I discovered a very strange issue where when requesting the transaction receipt after submitting a transaction I was receiving the wrong value for `receipt.status`. After much investigation I realized what was happening:

1. web3's send transaction method requests the receipt for its own PromiEvent monitoring
2. I also request web3.eth.getTransactionReceipt() in my own tracker, which the in-flight cache lumps into a single request
3. When the original response comes back it is parsed by web3 using the method's outputFormatters which has an unfortunately strict line:

```javascript
if (typeof receipt.status !== 'undefined') {
  receipt.status = Boolean(parseInt(receipt.status));
}
```

4. Since it is modifying the object directly, that gets passed on to the next handler, causing this to happen:

```javascript
// Initial run
parseInt('0x1') // 1
Boolean(1) // true
```
```javascript
// Second run
parseInt(true) // NaN
Boolean(NaN) // false
```

The solution here is to make sure that we copy the result before submitting to each handler so that the changes are not propagated. This is just one case where it caused issues for me, but I'm sure there are others. FWIW, I am also opening a PR with web3.js for this particular issue.

I'm using `Object.assign` in this PR, but if ES2015 is too modern this can be achieved with `JSON.parse(JSON.stringify(result))` since the result should always be primitive values here anyway.