### PR TITLE
docs: New package names for @metamask/json-rpc-engine and @metamask/eth-json-rpc-middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Web3 ProviderEngine is a tool for composing your own [web3 providers](https://github.com/ethereum/wiki/wiki/JavaScript-API#web3).
 
-<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><div align="center">This package was originally created for MetaMask and is being phased out in favor of <a href="https://www.npmjs.com/package/json-rpc-engine"><code>json-rpc-engine</code></a> and <a href="https://www.npmjs.com/package/eth-json-rpc-middleware"><code>eth-json-rpc-middleware</code></a>. As such, we will no longer be accepting changes to this package except those which address security issues.</div></td></tr></table>
+<table><tr><td><p align="center"><b>⚠️ PLEASE READ ⚠️</b></p><div align="center">This package was originally created for MetaMask and is being phased out in favor of <a href="https://www.npmjs.com/package/@metamask/json-rpc-engine"><code>@metamask/json-rpc-engine</code></a> and <a href="https://www.npmjs.com/package/@metamask/eth-json-rpc-middleware"><code>@metamask/eth-json-rpc-middleware</code></a>. As such, we will no longer be accepting changes to this package except those which address security issues.</div></td></tr></table>
 
 ### Composable
 


### PR DESCRIPTION
The two replacement packages are now published under the `@metamask/` scope on npmjs.org. This updates the readme accordingly.

- https://www.npmjs.com/package/json-rpc-engine -> https://www.npmjs.com/package/@metamask/json-rpc-engine
- https://www.npmjs.com/package/eth-json-rpc-middleware -> https://www.npmjs.com/package/@metamask/eth-json-rpc-middleware