### PR TITLE
ci: bundle as part of build-lint-test workflow

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -20,6 +20,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - run: yarn --frozen-lockfile --ignore-scripts
       - run: yarn build
+      - run: yarn bundle
       - run: yarn lint
       - run: yarn test
   all-jobs-pass:


### PR DESCRIPTION
this adds a step running `yarn bundle` to CI, ensuring that regressions are not introduced affecting the bundles.