### PR TITLE
fix(etherscan,rpc): fix require of @cypress/request

### DIFF
--- a/subproviders/etherscan.js
+++ b/subproviders/etherscan.js
@@ -22,7 +22,7 @@
  * - eth_listTransactions (non-standard)
  */
 
-const xhr = process.browser ? require('xhr') : require('request')
+const xhr = process.browser ? require('xhr') : require('@cypress/request')
 const inherits = require('util').inherits
 const Subprovider = require('./subprovider.js')
 
@@ -38,18 +38,18 @@ function EtherscanProvider(opts) {
   this.times = isNaN(opts.times) ? 4 : opts.times;
   this.interval = isNaN(opts.interval) ? 1000 : opts.interval;
   this.retryFailed = typeof opts.retryFailed === 'boolean' ? opts.retryFailed : true; // not built yet
-  
+
   setInterval(this.handleRequests, this.interval, this);
 }
 
 EtherscanProvider.prototype.handleRequests = function(self){
 	if(self.requests.length == 0) return;
-	
+
 	//console.log('Handling the next ' + self.times + ' of ' + self.requests.length + ' requests');
-	
+
 	for(var requestIndex = 0; requestIndex < self.times; requestIndex++) {
 		var requestItem = self.requests.shift()
-  		
+
 		if(typeof requestItem !== 'undefined')
 			handlePayload(requestItem.proto, requestItem.network, requestItem.payload, requestItem.next, requestItem.end)
 	}
@@ -58,7 +58,7 @@ EtherscanProvider.prototype.handleRequests = function(self){
 EtherscanProvider.prototype.handleRequest = function(payload, next, end){
   var requestObject = {proto: this.proto, network: this.network, payload: payload, next: next, end: end},
 	  self = this;
-  
+
   if(this.retryFailed)
 	  requestObject.end = function(err, result){
 		  if(err === '403 - Forbidden: Access is denied.')
@@ -66,7 +66,7 @@ EtherscanProvider.prototype.handleRequest = function(payload, next, end){
 		  else
 			 end(err, result);
 		  };
-	
+
   this.requests.push(requestObject);
 }
 
@@ -189,7 +189,7 @@ function toQueryString(params) {
 
 function etherscanXHR(useGetMethod, proto, network, module, action, params, end) {
   var uri = proto + '://' + network + '.etherscan.io/api?' + toQueryString({ module: module, action: action }) + '&' + toQueryString(params)
-	
+
   xhr({
     uri: uri,
     method: useGetMethod ? 'GET' : 'POST',
@@ -202,8 +202,8 @@ function etherscanXHR(useGetMethod, proto, network, module, action, params, end)
     // console.log('[etherscan] response: ', err)
 
     if (err) return end(err)
-	
-	  /*console.log('[etherscan request]' 
+
+	  /*console.log('[etherscan request]'
 				  + ' method: ' + useGetMethod
 				  + ' proto: ' + proto
 				  + ' network: ' + network
@@ -211,10 +211,10 @@ function etherscanXHR(useGetMethod, proto, network, module, action, params, end)
 				  + ' action: ' + action
 				  + ' params: ' + params
 				  + ' return body: ' + body);*/
-	
+
     if(body.indexOf('403 - Forbidden: Access is denied.') > -1)
     	return end('403 - Forbidden: Access is denied.')
-	  
+
     var data
     try {
       data = JSON.parse(body)

--- a/subproviders/rpc.js
+++ b/subproviders/rpc.js
@@ -1,4 +1,4 @@
-const xhr = process.browser ? require('xhr') : require('request')
+const xhr = process.browser ? require('xhr') : require('@cypress/request')
 const inherits = require('util').inherits
 const createPayload = require('../util/create-payload.js')
 const Subprovider = require('./subprovider.js')


### PR DESCRIPTION
- Leftover from #441 : existing `require`s where still pulling in old version implicitly pulled in transitively. This fixes that.
- Backport for v16: #459